### PR TITLE
Improve health indicator

### DIFF
--- a/jwt-client/jwt-client-core/src/main/java/org/entur/jwt/client/AbstractAccessTokenHealthProvider.java
+++ b/jwt-client/jwt-client-core/src/main/java/org/entur/jwt/client/AbstractAccessTokenHealthProvider.java
@@ -1,0 +1,56 @@
+package org.entur.jwt.client;
+
+public abstract class AbstractAccessTokenHealthProvider extends BaseAccessTokenProvider {
+
+    /** The state of the below provider */
+    protected volatile AccessTokenHealth providerStatus;
+    
+    /** The state of the top level provider */
+    protected volatile AccessTokenHealth status;
+
+    /**
+     * Provider to invoke when refreshing state. This should be the top level
+     * provider, so that caches are actually populated and so on.
+     */
+
+    protected AccessTokenProvider refreshProvider;
+
+    public AbstractAccessTokenHealthProvider(AccessTokenProvider provider) {
+        super(provider);
+    }
+
+    @Override
+    public AccessToken getAccessToken(boolean forceRefresh) throws AccessTokenException {
+        long time = System.currentTimeMillis();
+
+        AccessToken accessToken = null;
+        try {
+            accessToken = provider.getAccessToken(forceRefresh);
+        } finally {
+            this.providerStatus = new AccessTokenHealth(time, accessToken != null);
+        }
+
+        return accessToken;
+    }
+
+    @Override
+    public AccessTokenHealth getHealth(boolean refresh) {
+        if(!refresh) {
+            AccessTokenHealth threadSafeStatus = this.status; // defensive copy
+            if(threadSafeStatus != null) {
+                return threadSafeStatus;
+            }
+            // not allowed to refresh
+            // use the latest underlying provider status, if available
+            return providerStatus;
+        }
+
+        return getRefreshHealth();
+    }
+
+    protected abstract AccessTokenHealth getRefreshHealth();
+
+    public void setRefreshProvider(AccessTokenProvider top) {
+        this.refreshProvider = top;
+    }
+}

--- a/jwt-client/jwt-client-core/src/main/java/org/entur/jwt/client/AbstractAccessTokenProvidersBuilder.java
+++ b/jwt-client/jwt-client-core/src/main/java/org/entur/jwt/client/AbstractAccessTokenProvidersBuilder.java
@@ -146,17 +146,22 @@ public abstract class AbstractAccessTokenProvidersBuilder<B extends AbstractAcce
         if (retrying) {
             provider = new RetryingAccessTokenProvider(provider);
         }
-        DefaultAccessTokenHealthProvider defaultAccessTokenHealthProvider = null;
+        AbstractAccessTokenHealthProvider healthProvider = null;
         if (health) {
-            provider = defaultAccessTokenHealthProvider = new DefaultAccessTokenHealthProvider(provider);
+            if(preemptiveRefresh && preemptiveRefreshEager) {
+                // used simplified health indicator
+                provider = healthProvider = new EagerAccessTokenHealthProvider(provider);
+            } else {
+                provider = healthProvider = new DefaultAccessTokenHealthProvider(provider);
+            }
         }
         if (preemptiveRefresh) {
             provider = new PreemptiveCachedAccessTokenProvider(provider, minimumTimeToLiveUnits, minimumTimeToLiveUnit, refreshExpiresIn, refreshExpiresUnit, preemptiveRefreshTimeUnits, preemptiveRefreshTimeUnit, preemptiveRefreshConstraint, preemptiveRefreshEager);
         } else if (cached) {
             provider = new DefaultCachedAccessTokenProvider(provider, minimumTimeToLiveUnits, minimumTimeToLiveUnit, refreshExpiresIn, refreshExpiresUnit);
         }
-        if (defaultAccessTokenHealthProvider != null) {
-            defaultAccessTokenHealthProvider.setRefreshProvider(provider);
+        if (healthProvider != null) {
+            healthProvider.setRefreshProvider(provider);
         }
         return provider;
     }

--- a/jwt-client/jwt-client-core/src/main/java/org/entur/jwt/client/AccessTokenHealthProvider.java
+++ b/jwt-client/jwt-client-core/src/main/java/org/entur/jwt/client/AccessTokenHealthProvider.java
@@ -6,10 +6,9 @@ public interface AccessTokenHealthProvider {
      * Get health. An implementation is expected to refresh the health status if
      * there is no current status, or if the last status was unsuccessful.
      * 
-     * @param refresh true if the provider should refresh a missing or bad health
-     *                status before returning.
+     * @param refresh true if the provider (optionally) can refresh the state before returning (typically if the health is missing or bad)
      * @throws AccessTokenHealthNotSupportedException if operation is not supported
-     * @return health status.
+     * @return health status, or null if none is available.
      */
 
     // implementation note: this might have returned a list, but we really do not

--- a/jwt-client/jwt-client-core/src/main/java/org/entur/jwt/client/EagerAccessTokenHealthProvider.java
+++ b/jwt-client/jwt-client-core/src/main/java/org/entur/jwt/client/EagerAccessTokenHealthProvider.java
@@ -1,0 +1,39 @@
+package org.entur.jwt.client;
+
+/**
+ * 
+ * Eager implementation of health provider. <br>
+ * <br>
+ * Calls to this health indicator can trigger a (remote) refresh even if the last call to the
+ * underlying provider was successful. 
+ *  
+ */
+
+public class EagerAccessTokenHealthProvider extends AbstractAccessTokenHealthProvider {
+
+    // implementation note: This is a more robust approach than the default implementation uses
+    // because we are allowed to refresh the token always.
+    
+    public EagerAccessTokenHealthProvider(AccessTokenProvider provider) {
+        super(provider);
+    }
+
+    @Override
+    protected AccessTokenHealth getRefreshHealth() {
+        AccessTokenHealth status = null;
+        // get a fresh status
+        AccessToken accessToken = null;
+        try {
+            accessToken = refreshProvider.getAccessToken(false);
+        } catch (Exception e) {
+            // ignore
+            logger.warn("Exception refreshing health status.", e);
+        } finally {
+            // as long as an access-token was returned, health is good
+            status = new AccessTokenHealth(System.currentTimeMillis(), accessToken != null);
+        }
+        this.status = status;
+        return status;
+    }
+
+}

--- a/jwt-server/jwk/jwk-core/src/main/java/org/entur/jwt/jwk/DefaultHealthJwksProvider.java
+++ b/jwt-server/jwk/jwk-core/src/main/java/org/entur/jwt/jwk/DefaultHealthJwksProvider.java
@@ -2,6 +2,9 @@ package org.entur.jwt.jwk;
 
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * 
  * Default 'lazy' implementation of health provider. <br>
@@ -18,6 +21,8 @@ import java.util.List;
  */
 
 public class DefaultHealthJwksProvider<T> extends BaseJwksProvider<T> {
+
+    private static final Logger logger = LoggerFactory.getLogger(DefaultHealthJwksProvider.class);
 
 	/** The state of the below provider */
     private volatile JwksHealth providerStatus;
@@ -43,13 +48,13 @@ public class DefaultHealthJwksProvider<T> extends BaseJwksProvider<T> {
         try {
             list = provider.getJwks(forceUpdate);
         } finally {
-            setStatus(new JwksHealth(time, list != null));
+            setProviderStatus(new JwksHealth(time, list != null));
         }
 
         return list;
     }
 
-    protected void setStatus(JwksHealth status) {
+    protected void setProviderStatus(JwksHealth status) {
         this.providerStatus = status;
     }
 

--- a/jwt-server/jwk/jwk-core/src/test/java/org/entur/jwt/jwk/DefaultHealthJwksProviderTest.java
+++ b/jwt-server/jwk/jwk-core/src/test/java/org/entur/jwt/jwk/DefaultHealthJwksProviderTest.java
@@ -1,8 +1,11 @@
 package org.entur.jwt.jwk;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
@@ -13,32 +16,51 @@ import org.mockito.Mockito;
 public class DefaultHealthJwksProviderTest extends AbstractDelegateProviderTest {
 
     private DefaultHealthJwksProvider<JwkImpl> provider;
-
+    private JwksProvider<JwkImpl> refreshProvider = mock(JwksProvider.class);
+    
     @BeforeEach
     public void setUp() throws Exception {
         super.setUp();
         provider = new DefaultHealthJwksProvider<>(delegate);
+        provider.setRefreshProvider(refreshProvider);
+        
+        when(refreshProvider.getJwks(false)).thenReturn(jwks);
+        when(refreshProvider.getJwks(true)).thenReturn(jwks);
+    }
+
+    
+    @Test
+    public void shouldReturnUnknownHealthIfNoPreviousStatusAndRefreshingIsNotAllowed() throws Exception {
+        JwksHealth health = provider.getHealth(false);
+        assertNull(health);
+
+        // expected behavior: the health provider did not attempt to refresh status.
+        Mockito.verify(refreshProvider, times(0)).getJwks(false);
+        Mockito.verify(delegate, times(0)).getJwks(false);
     }
 
     @Test
-    public void shouldReturnGoodHealthWhenUnderlyingProviderReturnsJwks() throws Exception {
+    public void shouldReturnGoodHealth() throws Exception {
         when(delegate.getJwks(false)).thenReturn(jwks);
 
-        // attempt to get jwks
+        // attempt to get access-token
         provider.getJwks(false);
 
-        JwksHealth health = provider.getHealth(false);
-        assertThat(health.isSuccess(), equalTo(true));
+        JwksHealth health1 = provider.getHealth(true);
+        assertTrue(health1.isSuccess());
+
+        JwksHealth health2 = provider.getHealth(false);
+        assertSame(health1, health2);
 
         // expected behavior: the health provider did not attempt to refresh
         // a good health status.
         Mockito.verify(delegate, times(1)).getJwks(false);
+        Mockito.verify(refreshProvider, times(0)).getJwks(false);
     }
 
     @Test
-    public void shouldReturnBadHealthWhenUnderlyingProviderThrowsException() throws Exception {
+    public void shouldReturnGoodHealthIfJwksCouldBeRefreshedAfterBadStatus() throws Exception {
         when(delegate.getJwks(false)).thenThrow(new JwksException());
-        provider.setRefreshProvider(provider);
 
         // attempt to get jwks
         assertThrows(JwksException.class, () -> {
@@ -46,24 +68,55 @@ public class DefaultHealthJwksProviderTest extends AbstractDelegateProviderTest 
         });
 
         JwksHealth health = provider.getHealth(true);
-        assertThat(health.isSuccess(), equalTo(false));
-        Mockito.verify(delegate, times(2)).getJwks(false);
-    }
+        assertTrue(health.isSuccess());
+
+        // expected behavior: the health provider refreshed
+        // a bad health status.
+        Mockito.verify(delegate, times(1)).getJwks(false);
+        Mockito.verify(refreshProvider, times(1)).getJwks(false);
+    }    
+
+    @Test
+    public void shouldReturnBadHealthIfJwksCouldNotBeRefreshedAfterBadStatus() throws Exception {
+        when(delegate.getJwks(false)).thenThrow(new JwksException());
+        when(refreshProvider.getJwks(false)).thenThrow(new JwksException());
+
+        // attempt to get jwks
+        assertThrows(JwksException.class, () -> {
+            provider.getJwks(false);
+        });
+
+        JwksHealth health = provider.getHealth(true);
+        assertFalse(health.isSuccess());
+
+        // expected behavior: the health provider refreshed
+        // a bad health status.
+        Mockito.verify(delegate, times(1)).getJwks(false);
+        Mockito.verify(refreshProvider, times(1)).getJwks(false);
+    }    
+  
 
     @Test
     public void shouldRecoverFromBadHealth() throws Exception {
         when(delegate.getJwks(false)).thenThrow(new JwksException()) // fail
                 .thenReturn(jwks); // recover
-        provider.setRefreshProvider(provider);
 
-        // trigger fail
+        // attempt to get access-token
         assertThrows(JwksException.class, () -> {
             provider.getJwks(false);
         });
+        provider.getJwks(false);
 
-        JwksHealth health = provider.getHealth(true); // trigger recover
-        assertThat(health.isSuccess(), equalTo(true));
+        JwksHealth health1 = provider.getHealth(false);
+        assertTrue(health1.isSuccess());
+        
+        JwksHealth health2 = provider.getHealth(true);
+        assertSame(health1, health2);
+        
         Mockito.verify(delegate, times(2)).getJwks(false);
-    }
-
+        Mockito.verify(refreshProvider, times(0)).getJwks(false);
+    }    
+    
+    
+    
 }

--- a/jwt-server/spring/jwt-spring-camel/pom.xml
+++ b/jwt-server/spring/jwt-spring-camel/pom.xml
@@ -13,7 +13,7 @@
 		<spring-boot.version>2.1.18.RELEASE</spring-boot.version>
 		<spring.version>5.1.20.RELEASE</spring.version>
 		
-		<tomcat.version>9.0.44</tomcat.version>
+		<tomcat.version>9.0.46</tomcat.version>
 	</properties>
 
 	<dependencyManagement>

--- a/jwt-server/spring/jwt-spring-core/src/main/java/org/entur/jwt/spring/actuate/JwksHealthIndicator.java
+++ b/jwt-server/spring/jwt-spring-core/src/main/java/org/entur/jwt/spring/actuate/JwksHealthIndicator.java
@@ -28,14 +28,18 @@ public class JwksHealthIndicator extends AbstractHealthIndicator {
     @Override
     protected void doHealthCheck(Health.Builder builder) throws Exception {
         JwksHealth health = jwtVerifier.getHealth(true);
-        
-        logInitialOrChangedState(health);
-        if (health.isSuccess()) {
-            builder.up();
+        if(health != null) {
+	        logInitialOrChangedState(health);
+	        if (health.isSuccess()) {
+	            builder.up();
+	        } else {
+	            builder.down();
+	        }
+	        builder.withDetail("timestamp", health.getTimestamp());
         } else {
-            builder.down();
+        	// should never happen
+        	builder.unknown();
         }
-        builder.withDetail("timestamp", health.getTimestamp());
     }
 
     protected void logInitialOrChangedState(JwksHealth health) {

--- a/jwt-server/spring/jwt-spring-grpc/pom.xml
+++ b/jwt-server/spring/jwt-spring-grpc/pom.xml
@@ -10,12 +10,12 @@
     <artifactId>jwt-spring-grpc</artifactId>
 
     <properties>
-        <grpc.version>1.37.0</grpc.version>
-        <proto.version>3.13.0</proto.version>
-        <lognet.version>4.4.5</lognet.version>
+        <grpc.version>1.38.0</grpc.version>
+        <proto.version>3.17.3</proto.version>
+        <lognet.version>4.5.3</lognet.version>
         <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
         <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
-    </properties>
+    </properties>	
 
     <dependencies>
         <dependency>

--- a/jwt-server/spring/jwt-spring-grpc/src/test/resources/application.yaml
+++ b/jwt-server/spring/jwt-spring-grpc/src/test/resources/application.yaml
@@ -30,3 +30,4 @@ entur:
 
 grpc:
   port: 0
+  security.auth.enabled: false

--- a/pom.xml
+++ b/pom.xml
@@ -66,17 +66,17 @@
 		<bucket4j-core.version>4.10.0</bucket4j-core.version>
 		<jackson-databind.version>2.11.4</jackson-databind.version>
 		<camel.version>2.25.3</camel.version>
-		<jwks-rsa.version>0.17.0</jwks-rsa.version>
-		<java-jwt.version>3.15.0</java-jwt.version>
+		<jwks-rsa.version>0.18.0</jwks-rsa.version>
+		<java-jwt.version>3.16.0</java-jwt.version>
 		<jadler.version>1.3.0</jadler.version>
-		<spring-boot.version>2.4.4</spring-boot.version>
-		<spring.version>5.3.5</spring.version>
+		<spring-boot.version>2.4.7</spring-boot.version>
+		<spring.version>5.3.8</spring.version>
 		<rest-assured.version>4.3.3</rest-assured.version>
 		
 		<!-- https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies  -->
 		<!-- transient dependencies added due to security patching -->
 		<snakeyaml.version>1.27</snakeyaml.version>
-		<tomcat.version>9.0.44</tomcat.version>
+		<tomcat.version>9.0.46</tomcat.version>
 		
 		<!-- plugins -->
 		<build-helper-maven-plugin.version>1.9.1</build-helper-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 		<nimbus-jose-jwt.version>9.4.1</nimbus-jose-jwt.version>
 		<bucket4j-core.version>4.10.0</bucket4j-core.version>
 		<jackson-databind.version>2.11.4</jackson-databind.version>
-		<camel.version>2.25.3</camel.version>
+		<camel.version>2.25.4</camel.version>
 		<jwks-rsa.version>0.18.0</jwks-rsa.version>
 		<java-jwt.version>3.16.0</java-jwt.version>
 		<jadler.version>1.3.0</jadler.version>


### PR DESCRIPTION
Improve health indicator when status fails. 

Simplify logic when eagerily fetching JWTs.