### PR TITLE
More robust error handling configuration for grpc

### DIFF
--- a/examples/jwt-client-spring-boot-example/pom.xml
+++ b/examples/jwt-client-spring-boot-example/pom.xml
@@ -11,7 +11,7 @@
 	<artifactId>jwt-client-spring-boot-example</artifactId>
 	<name>jwt-client-spring-boot-example</name>
 	<description>Demo project for Spring Boot</description>
-	<version>4.1.0-SNAPSHOT</version>
+	<version>4.1.1-SNAPSHOT</version>
 
 	<properties>
 		<java.version>17</java.version>

--- a/examples/jwt-resource-server-spring-boot-example/pom.xml
+++ b/examples/jwt-resource-server-spring-boot-example/pom.xml
@@ -11,7 +11,7 @@
 	<artifactId>jwt-resource-server-spring-boot-example</artifactId>
 	<name>jwt-resource-server-spring-boot-example</name>
 	<description>Demo project for Spring Boot</description>
-	<version>4.1.0-SNAPSHOT</version>
+	<version>4.1.1-SNAPSHOT</version>
 
 	<properties>
 		<java.version>17</java.version>

--- a/jwt-server/spring/jwt-spring-grpc/src/main/java/org/entur/jwt/spring/grpc/annotate/ConditionalOnMissingErrorHandlerForExactException.java
+++ b/jwt-server/spring/jwt-spring-grpc/src/main/java/org/entur/jwt/spring/grpc/annotate/ConditionalOnMissingErrorHandlerForExactException.java
@@ -1,0 +1,22 @@
+package org.entur.jwt.spring.grpc.annotate;
+
+
+import org.springframework.context.annotation.Conditional;
+
+import java.lang.annotation.*;
+
+
+/**
+ *
+ * The regular {@linkplain org.lognet.springboot.grpc.autoconfigure.ConditionalOnMissingErrorHandler} also checks for handling of the subtree,
+ * but we don't want that since this will result in incorrect return codes.
+ *
+ */
+
+@Target({ ElementType.TYPE , ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Conditional(OnMissingErrorHandlerForExactExceptionCondition.class)
+public @interface ConditionalOnMissingErrorHandlerForExactException {
+    Class<? extends Throwable> value();
+}

--- a/jwt-server/spring/jwt-spring-grpc/src/main/java/org/entur/jwt/spring/grpc/annotate/OnMissingErrorHandlerForExactExceptionCondition.java
+++ b/jwt-server/spring/jwt-spring-grpc/src/main/java/org/entur/jwt/spring/grpc/annotate/OnMissingErrorHandlerForExactExceptionCondition.java
@@ -1,0 +1,48 @@
+package org.entur.jwt.spring.grpc.annotate;
+
+import org.lognet.springboot.grpc.recovery.GRpcExceptionHandler;
+import org.lognet.springboot.grpc.recovery.GRpcServiceAdvice;
+import org.lognet.springboot.grpc.recovery.HandlerMethod;
+import org.springframework.boot.autoconfigure.condition.ConditionOutcome;
+import org.springframework.boot.autoconfigure.condition.SpringBootCondition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.MethodIntrospector;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.util.ReflectionUtils;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+public class OnMissingErrorHandlerForExactExceptionCondition extends SpringBootCondition {
+    @Override
+    public ConditionOutcome getMatchOutcome(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        Class<? extends Throwable> exc = (Class<? extends Throwable>) metadata
+                .getAnnotationAttributes(ConditionalOnMissingErrorHandlerForExactException.class.getName())
+                .get("value");
+
+        ReflectionUtils.MethodFilter f = method -> AnnotatedElementUtils.hasAnnotation(method, GRpcExceptionHandler.class);
+        for(String adviceBeanName:context.getBeanFactory().getBeanNamesForAnnotation(GRpcServiceAdvice.class)){
+            final String beanClassName = context.getBeanFactory().getBeanDefinition(adviceBeanName)
+                    .getBeanClassName();
+
+            try {
+                for (Method method : MethodIntrospector.selectMethods(Class.forName(beanClassName), f)) {
+                    final Optional<Class<? extends Throwable>> handledException = HandlerMethod.getHandledException(method, false);
+                    if(handledException.isPresent() && handledException.get().equals(exc)){
+                        return ConditionOutcome.noMatch(String.format("Found %s handler at %s.%s",
+                                handledException.get().getName(),
+                                beanClassName,
+                                method.getName()
+                                ));
+                    }
+                }
+            } catch (ClassNotFoundException e) {
+                throw  new IllegalStateException(e);
+            }
+        };
+
+        return ConditionOutcome.match();
+    }
+}
+


### PR DESCRIPTION
Make sure the authentication error handlers are activated even if a more generic error handler is present, so that the return status codes are correct.