### PR TITLE
Recover health in the background

### DIFF
--- a/examples/jwt-resource-server-spring-boot-example/src/test/java/org/entur/jwt/spring/demo/ActuatorTest.java
+++ b/examples/jwt-resource-server-spring-boot-example/src/test/java/org/entur/jwt/spring/demo/ActuatorTest.java
@@ -26,8 +26,6 @@ public class ActuatorTest {
 
     public void waitForHealth() throws Exception {
         // make sure health is ready before visiting
-        healthIndicator.getHealth(false);
-
         long deadline = System.currentTimeMillis() + 1000;
         while (System.currentTimeMillis() < deadline && !healthIndicator.isIdle()) {
             Thread.sleep(10);
@@ -36,6 +34,7 @@ public class ActuatorTest {
 
     @Test
     public void actuatorHealth() throws Exception {
+        given().port(port).log().all().when().get("/actuator/health/readiness").then().log().all().assertThat().statusCode(HttpStatus.SERVICE_UNAVAILABLE.value());
         waitForHealth();
 
         given().port(port).log().all().when().get("/actuator/health/readiness").then().log().all().assertThat().statusCode(HttpStatus.OK.value());

--- a/examples/jwt-resource-server-spring-boot-example/src/test/java/org/entur/jwt/spring/demo/ActuatorTest.java
+++ b/examples/jwt-resource-server-spring-boot-example/src/test/java/org/entur/jwt/spring/demo/ActuatorTest.java
@@ -1,7 +1,9 @@
 package org.entur.jwt.spring.demo;
 
 import org.entur.jwt.junit5.AuthorizationServer;
+import org.entur.jwt.spring.actuate.ListJwksHealthIndicator;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
@@ -16,11 +18,26 @@ public class ActuatorTest {
 
     // see also alternative approach with com.jayway.restassured:spring-mock-mvc
 
+    @Autowired
+    private ListJwksHealthIndicator healthIndicator;
+
     @LocalServerPort
     private Integer port;
 
+    public void waitForHealth() throws Exception {
+        // make sure health is ready before visiting
+        healthIndicator.getHealth(false);
+
+        long deadline = System.currentTimeMillis() + 1000;
+        while (System.currentTimeMillis() < deadline && !healthIndicator.isIdle()) {
+            Thread.sleep(10);
+        }
+    }
+
     @Test
-    public void actuatorHealth() {
+    public void actuatorHealth() throws Exception {
+        waitForHealth();
+
         given().port(port).log().all().when().get("/actuator/health/readiness").then().log().all().assertThat().statusCode(HttpStatus.OK.value());
     }
 

--- a/jwt-client/jwt-client-spring-core/src/main/java/org/entur/jwt/client/spring/JwtClientAutoConfiguration.java
+++ b/jwt-client/jwt-client-spring-core/src/main/java/org/entur/jwt/client/spring/JwtClientAutoConfiguration.java
@@ -14,7 +14,6 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
 import org.springframework.beans.factory.support.GenericBeanDefinition;
 import org.springframework.boot.actuate.autoconfigure.health.ConditionalOnEnabledHealthIndicator;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.bind.Binder;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.Bean;
@@ -23,6 +22,9 @@ import org.springframework.lang.Nullable;
 
 import java.util.*;
 import java.util.Map.Entry;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class JwtClientAutoConfiguration {
@@ -128,7 +130,7 @@ public class JwtClientAutoConfiguration {
     @Bean
     @ConditionalOnEnabledHealthIndicator("jwts")
     public AccessTokenProviderHealthIndicator jwtsHealthIndicator(Map<String, AccessTokenProvider> providers) {
-        // could verify that health is supported here, but that would interfere with
+        // could trigger health update here, but that would interfere with
         // mocking / testing.
         List<String> statusProviders = new ArrayList<>();
         for (Entry<String, AccessTokenProvider> entry : providers.entrySet()) {
@@ -146,7 +148,19 @@ public class JwtClientAutoConfiguration {
             log.info("Add health-indicator for {}/{} access-token provider(s) {}", statusProviders.size(), providers.size(), statusProviders.stream().collect(Collectors.joining("', '", "'", "'")));
         }
 
-        return new AccessTokenProviderHealthIndicator(statusProviders.stream().map(key -> providers.get(key)).collect(Collectors.toList()));
+        ThreadPoolExecutor executor = new ThreadPoolExecutor(0, Integer.MAX_VALUE,
+                60L, TimeUnit.SECONDS,
+                new SynchronousQueue<>());
+
+        AccessTokenProviderHealthIndicator list = new AccessTokenProviderHealthIndicator(executor, "List");
+
+        for (String key : statusProviders) {
+            AccessTokenProvider accessTokenProvider = providers.get(key);
+
+            list.addHealthIndicators(key, accessTokenProvider);
+        }
+
+        return list;
     }
 
     @Bean

--- a/jwt-client/jwt-client-spring-core/src/main/java/org/entur/jwt/client/spring/JwtClientAutoConfiguration.java
+++ b/jwt-client/jwt-client-spring-core/src/main/java/org/entur/jwt/client/spring/JwtClientAutoConfiguration.java
@@ -22,9 +22,7 @@ import org.springframework.lang.Nullable;
 
 import java.util.*;
 import java.util.Map.Entry;
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.stream.Collectors;
 
 public class JwtClientAutoConfiguration {
@@ -148,11 +146,7 @@ public class JwtClientAutoConfiguration {
             log.info("Add health-indicator for {}/{} access-token provider(s) {}", statusProviders.size(), providers.size(), statusProviders.stream().collect(Collectors.joining("', '", "'", "'")));
         }
 
-        ThreadPoolExecutor executor = new ThreadPoolExecutor(0, Integer.MAX_VALUE,
-                60L, TimeUnit.SECONDS,
-                new SynchronousQueue<>());
-
-        AccessTokenProviderHealthIndicator list = new AccessTokenProviderHealthIndicator(executor, "List");
+        AccessTokenProviderHealthIndicator list = new AccessTokenProviderHealthIndicator(Executors.newCachedThreadPool(), "List");
 
         for (String key : statusProviders) {
             AccessTokenProvider accessTokenProvider = providers.get(key);

--- a/jwt-client/jwt-client-spring-core/src/main/java/org/entur/jwt/client/spring/actuate/AbstractJwtHealthIndicator.java
+++ b/jwt-client/jwt-client-spring-core/src/main/java/org/entur/jwt/client/spring/actuate/AbstractJwtHealthIndicator.java
@@ -1,0 +1,68 @@
+package org.entur.jwt.client.spring.actuate;
+
+import org.entur.jwt.client.AccessTokenHealth;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+
+/**
+ * 
+ * Health indicator.
+ * 
+ */
+
+public abstract class AbstractJwtHealthIndicator extends AbstractHealthIndicator {
+
+    private static final Logger logger = LoggerFactory.getLogger(AbstractJwtHealthIndicator.class);
+
+    private AccessTokenHealth previousHealth;
+
+    protected final String name;
+
+    protected AbstractJwtHealthIndicator(String name) {
+        this.name = name;
+    }
+
+    @Override
+    protected void doHealthCheck(Health.Builder builder) throws Exception {
+
+        AccessTokenHealth health = refreshHealth();
+        if(health != null) {
+	        logInitialOrChangedState(health);
+	        if (health.isSuccess()) {
+	            builder.up();
+	        } else {
+	            builder.down();
+	        }
+	        builder.withDetail("timestamp", health.getTimestamp());
+        } else {
+        	// should never happen
+        	builder.unknown();
+        }
+    }
+
+    protected abstract AccessTokenHealth refreshHealth();
+
+    protected void logInitialOrChangedState(AccessTokenHealth health) {
+        AccessTokenHealth previousHealth = this.previousHealth; // defensive copy
+        if (previousHealth != null) {
+            if (!previousHealth.isSuccess() && health.isSuccess()) {
+                logger.info("{} JWT health transitioned to UP", name);
+            } else if (previousHealth.isSuccess() && !health.isSuccess()) {
+                logger.warn("{} JWT health transitioned to DOWN", name);
+            }
+        } else {
+            if (!health.isSuccess()) {
+                logger.warn("{} JWT health initialized to DOWN", name);
+            } else {
+                logger.info("{} JWT health initialized to UP", name);
+            }
+        }
+        this.previousHealth = health;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/jwt-client/jwt-client-spring-core/src/main/java/org/entur/jwt/client/spring/actuate/AccessTokenProviderHealthIndicator.java
+++ b/jwt-client/jwt-client-spring-core/src/main/java/org/entur/jwt/client/spring/actuate/AccessTokenProviderHealthIndicator.java
@@ -70,7 +70,7 @@ public class AccessTokenProviderHealthIndicator extends AbstractJwtHealthIndicat
 
     private volatile CountDownLatch countDownLatch = new CountDownLatch(0);
 
-    public AccessTokenProviderHealthIndicator(ThreadPoolExecutor executor, String name) {
+    public AccessTokenProviderHealthIndicator(ExecutorService executor, String name) {
         super(name);
         this.executor = executor;
     }

--- a/jwt-client/jwt-client-spring-core/src/main/java/org/entur/jwt/client/spring/actuate/AccessTokenProviderHealthIndicator.java
+++ b/jwt-client/jwt-client-spring-core/src/main/java/org/entur/jwt/client/spring/actuate/AccessTokenProviderHealthIndicator.java
@@ -1,15 +1,16 @@
 package org.entur.jwt.client.spring.actuate;
 
 import org.entur.jwt.client.AccessTokenHealth;
-import org.entur.jwt.client.AccessTokenHealthNotSupportedException;
 import org.entur.jwt.client.AccessTokenHealthProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.actuate.health.AbstractHealthIndicator;
-import org.springframework.boot.actuate.health.Health;
 
+import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ThreadPoolExecutor;
 
 /**
  * 
@@ -19,97 +20,166 @@ import java.util.List;
  * 
  */
 
-public class AccessTokenProviderHealthIndicator extends AbstractHealthIndicator {
+public class AccessTokenProviderHealthIndicator extends AbstractJwtHealthIndicator implements Closeable {
 
-    protected static final Logger logger = LoggerFactory.getLogger(AccessTokenProviderHealthIndicator.class);
+    protected static final Logger LOGGER = LoggerFactory.getLogger(AccessTokenProviderHealthIndicator.class);
 
-    private final AccessTokenHealthProvider[] providers;
-    
-    private Boolean previousHealthSuccess;
+    private static class JwtHealthIndicator {
 
-    public AccessTokenProviderHealthIndicator(AccessTokenHealthProvider[] statusProviders) {
-        super();
-        this.providers = statusProviders;
+        private final AccessTokenHealthProvider provider;
+        private final String name;
+
+        public JwtHealthIndicator(String name, AccessTokenHealthProvider provider) {
+            this.name = name;
+            this.provider = provider;
+        }
+
+        public AccessTokenHealth refreshHealth() {
+            long time = System.currentTimeMillis();
+
+            try {
+                // note: the cache will refresh if an existing value is expired or bad
+                return provider.getHealth(true);
+            } catch (Exception e) {
+                LOGGER.warn("Unable to refresh " + name + " JWT health status", e);
+                return new AccessTokenHealth(time, false);
+            }
+        }
+
+        public boolean isHealthy() {
+            // do not refresh health, get whatever it is currently
+            try {
+                AccessTokenHealth health = provider.getHealth(false);
+
+                return health != null && health.isSuccess();
+            } catch (Exception e) {
+                // should never happen
+                LOGGER.warn("Unable to get " + name + " JWT health status", e);
+                return false;
+            }
+        }
+
+        public String getName() {
+            return name;
+        }
     }
 
-    public AccessTokenProviderHealthIndicator(List<AccessTokenHealthProvider> statusProviders) {
-        this(statusProviders.toArray(new AccessTokenHealthProvider[statusProviders.size()]));
+
+    private ExecutorService executor;
+    private List<JwtHealthIndicator> healthIndicators = new ArrayList<>();
+
+    private volatile CountDownLatch countDownLatch = new CountDownLatch(0);
+
+    public AccessTokenProviderHealthIndicator(ThreadPoolExecutor executor, String name) {
+        super(name);
+        this.executor = executor;
+    }
+
+    public void addHealthIndicators(String name, AccessTokenHealthProvider provider) {
+        this.healthIndicators.add(new JwtHealthIndicator(name, provider));
     }
 
     @Override
-    protected void doHealthCheck(Health.Builder builder) throws Exception {
-        if(providers.length > 0) {
-            try {
-                // iterate over clients, and record the min / max timestamps.
-                boolean success = true;
-                long mostRecentTimestamp = Long.MIN_VALUE;
-                long leastRecentTimestamp = Long.MAX_VALUE;
-    
-                List<AccessTokenHealth> accessTokenHealths = new ArrayList<>(providers.length);
-                for(AccessTokenHealthProvider provider : providers) {
-                    AccessTokenHealth status = provider.getHealth(true);
-                    if(status != null) {
-                        accessTokenHealths.add(status);
-                    }
-                }
-    
-                if(!accessTokenHealths.isEmpty()) {
-                    for (AccessTokenHealth status : accessTokenHealths) {
-                        if (!status.isSuccess()) {
-                            success = false;
-                        }
-                        
-                        if(mostRecentTimestamp < status.getTimestamp()) {
-                            mostRecentTimestamp = status.getTimestamp();
-                        }
-                        if(leastRecentTimestamp > status.getTimestamp()) {
-                            leastRecentTimestamp = status.getTimestamp();
-                        }
-                    }
-                
-                    long time = System.currentTimeMillis();
-                    if(mostRecentTimestamp != Long.MIN_VALUE) {
-                        builder.withDetail("youngestTimestamp", (time - mostRecentTimestamp) / 1000);
-                    } 
-                    if(leastRecentTimestamp != Long.MAX_VALUE) {
-                        builder.withDetail("oldestTimestamp", (time - leastRecentTimestamp) / 1000);
-                    }
-                    
-                    logInitialOrChangedState(success);
-                    
-                    if (success) {
-                        builder.up();
-                    } else {
-                        builder.down();
-                    }
-                } else {
-                    // should never happen
-                    builder.unknown();
-                }
-            } catch (AccessTokenHealthNotSupportedException e) {
-                logger.error("Health checks are unexpectedly not supported", e);
-    
-                builder.unknown();
-            }
-        }
+    public void close() {
+        this.executor.shutdown();
     }
 
-    protected void logInitialOrChangedState(boolean success) {
-        Boolean previousSuccess = this.previousHealthSuccess; // defensive copy
-        if(previousSuccess != null) {
-            if(!previousSuccess && success) {
-                logger.info("Access-token-provider health transitioned to UP");
-            } else if(previousSuccess && !success) {
-                logger.warn("Access-token-provider health transitioned to DOWN");
-            }
-        } else {
-            if(!success) {
-                logger.warn("Access-token-provider health initialized to DOWN");
+    @Override
+    protected AccessTokenHealth refreshHealth() {
+        long time = System.currentTimeMillis();
+
+        List<JwtHealthIndicator> unhealthy = new ArrayList<>(healthIndicators.size());
+        List<JwtHealthIndicator> healthy = new ArrayList<>(healthIndicators.size());
+
+        for (JwtHealthIndicator healthIndicator : healthIndicators) {
+            if(healthIndicator.isHealthy()) {
+                healthy.add(healthIndicator);
             } else {
-                logger.info("Access-token-provider health initialized to UP");
+                unhealthy.add(healthIndicator);
             }
         }
-        this.previousHealthSuccess = success;
+
+        if(unhealthy.isEmpty()) {
+            return new AccessTokenHealth(time, true);
+        }
+
+        // attempt to recover the unhealthy status in the background, but only if work is not already in progress
+        synchronized (this) {
+            if(isIdle()) {
+                refreshHealth(healthy, unhealthy, time);
+            } else {
+                LOGGER.info("Previous health refresh is still in progress ({} outstanding)", countDownLatch.getCount());
+            }
+        }
+
+        return new AccessTokenHealth(time, false);
     }
 
+    private void refreshHealth(List<JwtHealthIndicator> healthy, List<JwtHealthIndicator> unhealthy, long time) {
+        countDownLatch = new CountDownLatch(unhealthy.size());
+
+        if(healthIndicators.size() > 1) {
+            // print summary
+            StringBuilder builder = new StringBuilder();
+            builder.append("Refreshing ");
+            builder.append(unhealthy.size());
+            builder.append(" unhealthy JWT sources (");
+            for (JwtHealthIndicator defaultJwksHealthIndicator : unhealthy) {
+                builder.append(defaultJwksHealthIndicator.getName());
+                builder.append(", ");
+            }
+            builder.setLength(builder.length() - 2);
+            builder.append(") in the background.");
+            if (!healthy.isEmpty()) {
+                builder.append(" The other ");
+                builder.append(healthy.size());
+                builder.append(" JWT sources (");
+                for (JwtHealthIndicator defaultJwksHealthIndicator : healthy) {
+                    builder.append(defaultJwksHealthIndicator.getName());
+                    builder.append(", ");
+                }
+                builder.setLength(builder.length() - 2);
+                builder.append(") are healthy.");
+            }
+
+            LOGGER.info(builder.toString());
+        }
+        for (JwtHealthIndicator indicator : unhealthy) {
+            executor.submit(() -> {
+                try {
+                    refresh(indicator, time);
+                } finally {
+                    countDownLatch.countDown();
+                }
+            });
+        }
+    }
+
+    private static boolean refresh(JwtHealthIndicator indicator, long time) {
+        // so either no status or bad status
+        // attempt to refresh the cache
+        LOGGER.info("Refresh {} JWT health", indicator.getName());
+
+        AccessTokenHealth health = indicator.refreshHealth();
+        if(health != null && health.isSuccess()) {
+            LOGGER.info("{} JWT is now healthy (in {}ms)", indicator.getName(), System.currentTimeMillis() - time);
+
+            return true;
+        } else {
+            LOGGER.info("{} JWT remains unhealthy (in {}ms)", indicator.getName(), System.currentTimeMillis() - time);
+
+            return false;
+        }
+    }
+
+    public boolean isIdle() {
+        synchronized (this) {
+            return countDownLatch.getCount() == 0L;
+        }
+    }
+
+    // for testing
+    public void setExecutor(ExecutorService executor) {
+        this.executor = executor;
+    }
 }

--- a/jwt-client/jwt-client-spring-webflux/src/test/java/org/entur/jwt/client/spring/webflux/AbstractActuatorTest.java
+++ b/jwt-client/jwt-client-spring-webflux/src/test/java/org/entur/jwt/client/spring/webflux/AbstractActuatorTest.java
@@ -1,0 +1,20 @@
+package org.entur.jwt.client.spring.webflux;
+
+import org.entur.jwt.client.spring.actuate.AccessTokenProviderHealthIndicator;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class AbstractActuatorTest {
+
+    @Autowired
+    private AccessTokenProviderHealthIndicator healthIndicator;
+
+    public void waitForHealth() throws Exception {
+        // make sure health is ready before visiting
+        long deadline = System.currentTimeMillis() + 10000;
+        while (System.currentTimeMillis() < deadline && !healthIndicator.isIdle()) {
+            Thread.sleep(100);
+
+            System.out.println("Sleep");
+        }
+    }
+}

--- a/jwt-client/jwt-client-spring-webflux/src/test/java/org/entur/jwt/client/spring/webflux/Auth0SingleClientTest.java
+++ b/jwt-client/jwt-client-spring-webflux/src/test/java/org/entur/jwt/client/spring/webflux/Auth0SingleClientTest.java
@@ -29,8 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @TestPropertySource(locations = "/application-auth0-single.properties")
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
-public class Auth0SingleClientTest {
-
+public class Auth0SingleClientTest extends AbstractActuatorTest {
 
     @LocalServerPort
     private int randomServerPort;
@@ -85,6 +84,10 @@ public class Auth0SingleClientTest {
         mockWebServer.enqueue(new MockResponse().setBody(asString(resource)));
 
         given().port(randomServerPort).log().all().when().get("/actuator/health/readiness").then().log().all().assertThat().statusCode(HttpStatus.SERVICE_UNAVAILABLE.value());
+        waitForHealth();
+        given().port(randomServerPort).log().all().when().get("/actuator/health/readiness").then().log().all().assertThat().statusCode(HttpStatus.SERVICE_UNAVAILABLE.value());
+        waitForHealth();
+
         given().port(randomServerPort).log().all().when().get("/actuator/health/readiness").then().log().all().assertThat().statusCode(HttpStatus.OK.value());
 
     }

--- a/jwt-client/jwt-client-spring/src/test/java/org/entur/jwt/client/spring/AbstractActuatorTest.java
+++ b/jwt-client/jwt-client-spring/src/test/java/org/entur/jwt/client/spring/AbstractActuatorTest.java
@@ -1,0 +1,20 @@
+package org.entur.jwt.client.spring;
+
+import org.entur.jwt.client.spring.actuate.AccessTokenProviderHealthIndicator;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class AbstractActuatorTest {
+
+    @Autowired
+    private AccessTokenProviderHealthIndicator healthIndicator;
+
+    public void waitForHealth() throws Exception {
+        // make sure health is ready before visiting
+        long deadline = System.currentTimeMillis() + 10000;
+        while (System.currentTimeMillis() < deadline && !healthIndicator.isIdle()) {
+            Thread.sleep(100);
+
+            System.out.println("Sleep");
+        }
+    }
+}

--- a/jwt-client/jwt-client-spring/src/test/java/org/entur/jwt/client/spring/Auth0SingleClientTest.java
+++ b/jwt-client/jwt-client-spring/src/test/java/org/entur/jwt/client/spring/Auth0SingleClientTest.java
@@ -35,7 +35,7 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @TestPropertySource(locations = "/application-auth0-single.properties")
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
-public class Auth0SingleClientTest {
+public class Auth0SingleClientTest extends AbstractActuatorTest {
 
     private MockRestServiceServer mockServer;
 
@@ -87,11 +87,16 @@ public class Auth0SingleClientTest {
     public void testActuator() throws Exception {
         // down
         mockServer.expect(ExpectedCount.twice(), requestTo(new URI("https://my.entur.org/oauth/token"))).andExpect(method(HttpMethod.POST)).andRespond(withStatus(HttpStatus.NOT_FOUND));
-        
+
         // up
         mockServer.expect(ExpectedCount.once(), requestTo(new URI("https://my.entur.org/oauth/token"))).andExpect(method(HttpMethod.POST)).andRespond(withStatus(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).body(resource));
         
         given().port(randomServerPort).log().all().when().get("/actuator/health/readiness").then().log().all().assertThat().statusCode(HttpStatus.SERVICE_UNAVAILABLE.value());
+        waitForHealth();
+
+        given().port(randomServerPort).log().all().when().get("/actuator/health/readiness").then().log().all().assertThat().statusCode(HttpStatus.SERVICE_UNAVAILABLE.value());
+        waitForHealth();
+
         given().port(randomServerPort).log().all().when().get("/actuator/health/readiness").then().log().all().assertThat().statusCode(HttpStatus.OK.value());
         
     }    

--- a/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/JwtAutoConfiguration.java
+++ b/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/JwtAutoConfiguration.java
@@ -23,10 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.concurrent.Executors;
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 @Configuration
 @EnableConfigurationProperties({SecurityProperties.class})
@@ -38,17 +35,7 @@ public class JwtAutoConfiguration {
     @Bean(destroyMethod = "close", value = "jwks")
     @ConditionalOnEnabledHealthIndicator("jwks")
     public ListJwksHealthIndicator jwksHealthIndicator(SecurityProperties properties) {
-        JwtProperties jwtProperties = properties.getJwt();
-        JwkProperties jwk = jwtProperties.getJwk();
-
-        // TODO should also the number of active provides be taken into account? Don't want the
-        // health check http response to time out
-        // from Executors.newCachedThreadPool()
-        ThreadPoolExecutor executor = new ThreadPoolExecutor(0, Integer.MAX_VALUE,
-                60L, TimeUnit.SECONDS,
-                new SynchronousQueue<Runnable>());
-
-        return new ListJwksHealthIndicator(executor, "List");
+        return new ListJwksHealthIndicator(Executors.newCachedThreadPool(), "List");
     }
 
     @Bean(destroyMethod = "close")

--- a/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/JwtAutoConfiguration.java
+++ b/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/JwtAutoConfiguration.java
@@ -24,6 +24,9 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.Executors;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 @Configuration
 @EnableConfigurationProperties({SecurityProperties.class})
@@ -40,10 +43,12 @@ public class JwtAutoConfiguration {
 
         // TODO should also the number of active provides be taken into account? Don't want the
         // health check http response to time out
+        // from Executors.newCachedThreadPool()
+        ThreadPoolExecutor executor = new ThreadPoolExecutor(0, Integer.MAX_VALUE,
+                60L, TimeUnit.SECONDS,
+                new SynchronousQueue<Runnable>());
 
-        long maxDelay = (jwk.getConnectTimeout() + jwk.getReadTimeout()) * 1000;
-
-        return new ListJwksHealthIndicator(maxDelay, Executors.newCachedThreadPool(), "List");
+        return new ListJwksHealthIndicator(executor, "List");
     }
 
     @Bean(destroyMethod = "close")

--- a/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/actuate/AbstractJwksHealthIndicator.java
+++ b/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/actuate/AbstractJwksHealthIndicator.java
@@ -13,7 +13,7 @@ import org.springframework.boot.actuate.health.Health;
 
 public abstract class AbstractJwksHealthIndicator extends AbstractHealthIndicator {
 
-    protected static final Logger logger = LoggerFactory.getLogger(AbstractJwksHealthIndicator.class);
+    private static final Logger logger = LoggerFactory.getLogger(AbstractJwksHealthIndicator.class);
 
     private JwksHealth previousHealth;
 
@@ -64,5 +64,9 @@ public abstract class AbstractJwksHealthIndicator extends AbstractHealthIndicato
             }
         }
         this.previousHealth = health;
+    }
+
+    public String getName() {
+        return name;
     }
 }

--- a/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/actuate/DefaultJwksHealthIndicator.java
+++ b/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/actuate/DefaultJwksHealthIndicator.java
@@ -58,10 +58,10 @@ public class DefaultJwksHealthIndicator extends AbstractJwksHealthIndicator impl
             return true;
         } catch (RateLimitReachedException e) {
             // log using a lower level
-            logger.info("Unable to refresh " + name + " {} JWKs health status, rate limit reached.");
+            logger.info("Unable to refresh {} JWKs health status, rate limit reached.", name);
             return false;
         } catch (Exception e) {
-            logger.warn("Unable to refresh " + name + " {} JWKs health status", e);
+            logger.warn("Unable to refresh " + name + " JWKs health status", e);
             return false;
         }
     }

--- a/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/actuate/ListJwksHealthIndicator.java
+++ b/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/actuate/ListJwksHealthIndicator.java
@@ -5,25 +5,20 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorCompletionService;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
+import java.util.Map;
+import java.util.concurrent.*;
 
 public class ListJwksHealthIndicator extends AbstractJwksHealthIndicator implements Closeable {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ListJwksHealthIndicator.class);
 
-    private final long maxDelay;
-
-    private final ExecutorService executorService;
+    private final ThreadPoolExecutor executorService;
     private List<DefaultJwksHealthIndicator> healthIndicators = new ArrayList<>();
 
-    public ListJwksHealthIndicator(long maxDelay, ExecutorService executorService, String name) {
+    public ListJwksHealthIndicator(ThreadPoolExecutor executorService, String name) {
         super(name);
-        this.maxDelay = maxDelay;
         this.executorService = executorService;
     }
 
@@ -43,9 +38,12 @@ public class ListJwksHealthIndicator extends AbstractJwksHealthIndicator impleme
         long time = System.currentTimeMillis();
 
         List<DefaultJwksHealthIndicator> unhealthy = new ArrayList<>(healthIndicators.size());
+        List<DefaultJwksHealthIndicator> healthy = new ArrayList<>(healthIndicators.size());
 
         for (DefaultJwksHealthIndicator healthIndicator : healthIndicators) {
-            if(!healthIndicator.isJwksHealtyReport()) {
+            if(healthIndicator.isJwksHealtyReport()) {
+                healthy.add(healthIndicator);
+            } else {
                 unhealthy.add(healthIndicator);
             }
         }
@@ -54,85 +52,65 @@ public class ListJwksHealthIndicator extends AbstractJwksHealthIndicator impleme
             return new JwksHealth(time, true);
         }
 
-        if(unhealthy.size() == 1) {
-            DefaultJwksHealthIndicator indicator = unhealthy.get(0);
-
-            // so either not status or bad status
-            // attempt to refresh the cache
-            if(indicator.refreshJwksHealth(time)) {
-                return new JwksHealth(time, true);
-            }
-            return new JwksHealth(time, false);
+        // attempt to recover the unhealthy status in the background, but only if work is not already in progress
+        if(executorService.getActiveCount() == 0 && executorService.getQueue().size() == 0) {
+            refreshHealth(healthy, unhealthy, time);
         }
 
-        // refresh multiple sources, wrap in completion service to visit them all in parallel
-        ExecutorCompletionService completionService = new ExecutorCompletionService(executorService);
+        return new JwksHealth(time, false);
+    }
 
-        List<Future<Boolean>> workerList = new ArrayList<>(unhealthy.size());
-
-        for (DefaultJwksHealthIndicator unhealthyJwksHealthIndicator : unhealthy) {
-            Future<Boolean> future = completionService.submit(() -> {
-                try {
-                    return unhealthyJwksHealthIndicator.refreshJwksHealth(time);
-                } catch(Exception e) {
-                    LOGGER.warn("Problem getting JWKs health", e);
-
-                    return false;
+    private void refreshHealth(List<DefaultJwksHealthIndicator> healthy, List<DefaultJwksHealthIndicator> unhealthy, long time) {
+        if(healthIndicators.size() > 1) {
+            // print summary
+            StringBuilder builder = new StringBuilder();
+            builder.append("Refreshing ");
+            builder.append(unhealthy.size());
+            builder.append(" unhealthy JWKs sources (");
+            for (DefaultJwksHealthIndicator defaultJwksHealthIndicator : unhealthy) {
+                builder.append(defaultJwksHealthIndicator.getName());
+                builder.append(", ");
+            }
+            builder.setLength(builder.length() - 2);
+            builder.append(") in the background.");
+            if (!healthy.isEmpty()) {
+                builder.append(" The other ");
+                builder.append(healthy.size());
+                builder.append(" JWKs sources (");
+                for (DefaultJwksHealthIndicator defaultJwksHealthIndicator : healthy) {
+                    builder.append(defaultJwksHealthIndicator.getName());
+                    builder.append(", ");
                 }
+                builder.setLength(builder.length() - 2);
+                builder.append(") are healthy.");
+            }
+
+            LOGGER.info(builder.toString());
+        }
+        for (DefaultJwksHealthIndicator indicator : unhealthy) {
+            executorService.submit(() -> {
+                refresh(indicator, time);
             });
+        }
+    }
 
-            workerList.add(future);
+    private static boolean refresh(DefaultJwksHealthIndicator indicator, long time) {
+
+        boolean previousReport = indicator.isHealthReport();
+        if(previousReport) {
+            LOGGER.info("Attempt to recover health for {} JWKs..", indicator.getName());
         }
 
-        Future<?> timeout = executorService.submit(() -> {
-            try {
-                Thread.sleep(maxDelay);
+        // so either not status or bad status
+        // attempt to refresh the cache
+        if(indicator.refreshJwksHealth(time)) {
+            LOGGER.info("{} JWKs is now healthy (in {}ms)", indicator.getName(), System.currentTimeMillis() - time);
 
-                LOGGER.warn("Timeout collecting " + workerList.size() + " JWKs health after" + maxDelay + "ms");
+            return true;
+        } else {
+            LOGGER.info("{} JWKs remains unhealthy (in {}ms)", indicator.getName(), System.currentTimeMillis() - time);
 
-                for (Future<Boolean> worker : workerList) {
-                    worker.cancel(true);
-                }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            } catch (Throwable e) {
-                // ignore
-            }
-        });
-
-        try {
-            // get the results as they come in
-            for (int i = 0; i < workerList.size(); i++) {
-                // if one fails, status is bad
-                // TODO add some kind of health policy
-                try {
-                    Future<Boolean> take = completionService.take();
-
-                    Boolean status = take.get();
-                    if (status != null && status) {
-                        continue;
-                    }
-                } catch(CancellationException e) {
-                    // ignore but return false
-                } catch (InterruptedException e) {
-                    // ignore but return false
-                    Thread.currentThread().interrupt();
-                } catch (ExecutionException e) {
-                    // this should not happen as the jobs are wrapped in try - catch
-                    LOGGER.warn("Problem getting health info", e);
-                } catch (Exception e) {
-                    // ignore
-                    LOGGER.info("Problem getting health info", e);
-                }
-                return new JwksHealth(time, false);
-            }
-            return new JwksHealth(time, true);
-        } finally {
-            timeout.cancel(true);
-
-            for (Future worker : workerList) {
-                worker.cancel(true);
-            }
+            return false;
         }
     }
 

--- a/jwt-server/spring/jwt-spring-web/src/test/java/org/entur/jwt/spring/actuate/AbstractActuatorTest.java
+++ b/jwt-server/spring/jwt-spring-web/src/test/java/org/entur/jwt/spring/actuate/AbstractActuatorTest.java
@@ -1,0 +1,18 @@
+package org.entur.jwt.spring.actuate;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class AbstractActuatorTest {
+
+    @Autowired
+    private ListJwksHealthIndicator healthIndicator;
+
+    public void waitForHealth() throws Exception {
+        long deadline = System.currentTimeMillis() + 10000;
+        while (System.currentTimeMillis() < deadline && !healthIndicator.isIdle()) {
+            Thread.sleep(100);
+
+            System.out.println("Sleep");
+        }
+    }
+}

--- a/jwt-server/spring/jwt-spring-web/src/test/java/org/entur/jwt/spring/actuate/ReadinessDisabledTest.java
+++ b/jwt-server/spring/jwt-spring-web/src/test/java/org/entur/jwt/spring/actuate/ReadinessDisabledTest.java
@@ -9,7 +9,6 @@ import org.springframework.test.context.TestPropertySource;
 @AuthorizationServer("unreliable")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = {
-        "entur.jwt.jwk.health-indicator.enabled=false",
         "management.endpoint.health.group.readiness.include=readinessState"
 })
 public class ReadinessDisabledTest {

--- a/jwt-server/spring/jwt-spring-web/src/test/java/org/entur/jwt/spring/actuate/ReadinessEndpointDownTest.java
+++ b/jwt-server/spring/jwt-spring-web/src/test/java/org/entur/jwt/spring/actuate/ReadinessEndpointDownTest.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
 
 import java.io.File;
 
@@ -29,7 +30,13 @@ import static org.junit.Assert.assertTrue;
 
 @AuthorizationServer("unreliable")
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-public class ReadinessEndpointDownTest {
+
+// speed up test
+@TestPropertySource(properties = {
+        "entur.jwt.jwk.rateLimit.enabled=false",
+})
+
+public class ReadinessEndpointDownTest extends AbstractActuatorTest {
 
     @LocalServerPort
     private int randomServerPort;
@@ -44,7 +51,8 @@ public class ReadinessEndpointDownTest {
     private ListJwksHealthIndicator indicator;
 
     @Test
-    public void testReadinessDownWithTransistionToUp() {
+    public void testReadinessDownWithTransistionToUp() throws Exception {
+        // make sure health is ready before visiting
         HttpHeaders headers = new HttpHeaders();
         HttpEntity<String> entity = new HttpEntity<String>(headers);
 
@@ -54,12 +62,17 @@ public class ReadinessEndpointDownTest {
         File jwkRenameFile = new File(jwkFile.getParentFile(), jwkFile.getName() + ".renamed");
         
         assertTrue(jwkFile.renameTo(jwkRenameFile));
-        
+
         ResponseEntity<String> down = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
         assertThat(down.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
-        
+        waitForHealth();
+
         assertTrue(jwkRenameFile.renameTo(jwkFile));
-        
+
+        down = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+        assertThat(down.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+
+        waitForHealth();
         ResponseEntity<String> up = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
         assertThat(up.getStatusCode()).isEqualTo(HttpStatus.OK);
     }

--- a/jwt-server/spring/jwt-spring-web/src/test/java/org/entur/jwt/spring/actuate/ReadinessEndpointUpTest.java
+++ b/jwt-server/spring/jwt-spring-web/src/test/java/org/entur/jwt/spring/actuate/ReadinessEndpointUpTest.java
@@ -14,6 +14,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 /**
  * 
  * Test readiness probe up. 
@@ -22,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @AuthorizationServer
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-public class ReadinessEndpointUpTest {
+public class ReadinessEndpointUpTest extends AbstractActuatorTest {
 
     @LocalServerPort
     private int randomServerPort;
@@ -34,14 +36,18 @@ public class ReadinessEndpointUpTest {
     private ListJwksHealthIndicator indicator;
 
     @Test
-    public void testReadiness() {
+    public void testReadiness() throws Exception {
         HttpHeaders headers = new HttpHeaders();
         HttpEntity<String> entity = new HttpEntity<String>(headers);
 
         String url = "http://localhost:" + randomServerPort + "/actuator/health/readiness";
 
         ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+        waitForHealth();
+
+        response = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+        assertTrue(response.getStatusCode().is2xxSuccessful());
     }
 
 }

--- a/jwt-server/spring/jwt-spring-web/src/test/java/org/entur/jwt/spring/rest/GreetingControllerUnauthenticatedWhitelist1Test.java
+++ b/jwt-server/spring/jwt-spring-web/src/test/java/org/entur/jwt/spring/rest/GreetingControllerUnauthenticatedWhitelist1Test.java
@@ -1,6 +1,7 @@
 package org.entur.jwt.spring.rest;
 
 import org.entur.jwt.junit5.AuthorizationServer;
+import org.entur.jwt.spring.actuate.AbstractActuatorTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,7 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = {"entur.authorization.permit-all.matcher.patterns=/actuator/health,/unprotected/**"})
-public class GreetingControllerUnauthenticatedWhitelist1Test {
+public class GreetingControllerUnauthenticatedWhitelist1Test extends AbstractActuatorTest {
 
     @LocalServerPort
     private int randomServerPort;
@@ -59,14 +60,17 @@ public class GreetingControllerUnauthenticatedWhitelist1Test {
     }
 
     @Test
-    public void testActuatorOnWhitelist() {
+    public void testActuatorOnWhitelist() throws Exception {
         HttpHeaders headers = new HttpHeaders();
         HttpEntity<String> entity = new HttpEntity<String>(headers);
 
         String url = "http://localhost:" + randomServerPort + "/actuator/health";
 
         ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+        assertTrue(response.getStatusCode().is5xxServerError());
+        waitForHealth();
 
+        response = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
         assertTrue(response.getStatusCode().is2xxSuccessful());
     }   
 }

--- a/jwt-server/spring/jwt-spring-web/src/test/java/org/entur/jwt/spring/rest/PermitAllAnyHttpMethodPatternTest.java
+++ b/jwt-server/spring/jwt-spring-web/src/test/java/org/entur/jwt/spring/rest/PermitAllAnyHttpMethodPatternTest.java
@@ -1,6 +1,7 @@
 package org.entur.jwt.spring.rest;
 
 import org.entur.jwt.junit5.AuthorizationServer;
+import org.entur.jwt.spring.actuate.ListJwksHealthIndicator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -27,6 +28,8 @@ public class PermitAllAnyHttpMethodPatternTest {
     @Autowired
     private TestRestTemplate restTemplate;
 
+    @Autowired
+    private ListJwksHealthIndicator healthIndicator;
     @Test
     public void testUnprotectedResourceWithPathVariableOnWhitelist() {
         HttpHeaders headers = new HttpHeaders();
@@ -40,7 +43,15 @@ public class PermitAllAnyHttpMethodPatternTest {
     }
 
     @Test
-    public void testActuatorOnWhitelist() {
+    public void testActuatorOnWhitelist() throws Exception {
+        // make sure health is ready before visiting
+        healthIndicator.getHealth(false);
+
+        long deadline = System.currentTimeMillis() + 1000;
+        while(System.currentTimeMillis() < deadline && !healthIndicator.isIdle()) {
+            Thread.sleep(10);
+        }
+
         HttpHeaders headers = new HttpHeaders();
         HttpEntity<String> entity = new HttpEntity<String>(headers);
 

--- a/jwt-server/spring/jwt-spring-web/src/test/java/org/entur/jwt/spring/rest/PermitAllGetHttpMethodPatternTest.java
+++ b/jwt-server/spring/jwt-spring-web/src/test/java/org/entur/jwt/spring/rest/PermitAllGetHttpMethodPatternTest.java
@@ -1,6 +1,7 @@
 package org.entur.jwt.spring.rest;
 
 import org.entur.jwt.junit5.AuthorizationServer;
+import org.entur.jwt.spring.actuate.ListJwksHealthIndicator;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -27,6 +28,9 @@ public class PermitAllGetHttpMethodPatternTest {
     @Autowired
     private TestRestTemplate restTemplate;
 
+    @Autowired
+    private ListJwksHealthIndicator healthIndicator;
+
     @Test
     public void testUnprotectedResourceWithPathVariableOnWhitelist() {
         HttpHeaders headers = new HttpHeaders();
@@ -40,7 +44,15 @@ public class PermitAllGetHttpMethodPatternTest {
     }
 
     @Test
-    public void testActuatorOnWhitelist() {
+    public void testActuatorOnWhitelist() throws Exception {
+        // make sure health is ready before visiting
+        healthIndicator.getHealth(false);
+
+        long deadline = System.currentTimeMillis() + 1000;
+        while(System.currentTimeMillis() < deadline && !healthIndicator.isIdle()) {
+            Thread.sleep(10);
+        }
+
         HttpHeaders headers = new HttpHeaders();
         HttpEntity<String> entity = new HttpEntity<String>(headers);
 

--- a/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/actuate/AbstractActuatorTest.java
+++ b/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/actuate/AbstractActuatorTest.java
@@ -9,8 +9,6 @@ public class AbstractActuatorTest {
 
     public void waitForHealth() throws Exception {
         // make sure health is ready before visiting
-        healthIndicator.getHealth(false);
-
         long deadline = System.currentTimeMillis() + 1000;
         while (System.currentTimeMillis() < deadline && !healthIndicator.isIdle()) {
             Thread.sleep(10);

--- a/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/actuate/AbstractActuatorTest.java
+++ b/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/actuate/AbstractActuatorTest.java
@@ -1,0 +1,19 @@
+package org.entur.jwt.spring.actuate;
+
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class AbstractActuatorTest {
+
+    @Autowired
+    private ListJwksHealthIndicator healthIndicator;
+
+    public void waitForHealth() throws Exception {
+        // make sure health is ready before visiting
+        healthIndicator.getHealth(false);
+
+        long deadline = System.currentTimeMillis() + 1000;
+        while (System.currentTimeMillis() < deadline && !healthIndicator.isIdle()) {
+            Thread.sleep(10);
+        }
+    }
+}

--- a/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/actuate/ReadinessEndpointDownTest.java
+++ b/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/actuate/ReadinessEndpointDownTest.java
@@ -60,12 +60,14 @@ public class ReadinessEndpointDownTest extends AbstractActuatorTest {
         
         assertTrue(jwkFile.renameTo(jwkRenameFile));
 
-        waitForHealth();
-
         ResponseEntity<String> down = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
         assertThat(down.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
-        
+        waitForHealth();
+
         assertTrue(jwkRenameFile.renameTo(jwkFile));
+
+        down = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+        assertThat(down.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
 
         waitForHealth();
 

--- a/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/actuate/ReadinessEndpointDownTest.java
+++ b/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/actuate/ReadinessEndpointDownTest.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.TestPropertySource;
 
 import java.io.File;
 
@@ -29,7 +30,13 @@ import static org.junit.Assert.assertTrue;
 
 @AuthorizationServer("unreliable")
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-public class ReadinessEndpointDownTest {
+
+// speed up test
+@TestPropertySource(properties = {
+        "entur.jwt.jwk.rateLimit.enabled=false",
+})
+
+public class ReadinessEndpointDownTest extends AbstractActuatorTest {
 
     @LocalServerPort
     private int randomServerPort;
@@ -40,8 +47,9 @@ public class ReadinessEndpointDownTest {
     @Value("${entur.jwt.tenants.unreliable.jwk.location}")
     private String jwkLocation;
 
+
     @Test 
-    public void testReadinessDownWithTransistionToUp() {
+    public void testReadinessDownWithTransistionToUp() throws Exception {
         HttpHeaders headers = new HttpHeaders();
         HttpEntity<String> entity = new HttpEntity<String>(headers);
 
@@ -51,12 +59,16 @@ public class ReadinessEndpointDownTest {
         File jwkRenameFile = new File(jwkFile.getParentFile(), jwkFile.getName() + ".renamed");
         
         assertTrue(jwkFile.renameTo(jwkRenameFile));
-        
+
+        waitForHealth();
+
         ResponseEntity<String> down = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
         assertThat(down.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
         
         assertTrue(jwkRenameFile.renameTo(jwkFile));
-        
+
+        waitForHealth();
+
         ResponseEntity<String> up = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
         assertThat(up.getStatusCode()).isEqualTo(HttpStatus.OK);
     }

--- a/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/actuate/ReadinessEndpointUpTest.java
+++ b/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/actuate/ReadinessEndpointUpTest.java
@@ -31,19 +31,20 @@ public class ReadinessEndpointUpTest extends AbstractActuatorTest {
     @Autowired
     private TestRestTemplate restTemplate;
 
-    @Autowired
-    private ListJwksHealthIndicator healthIndicator;
     @Test
     public void testReadiness() throws Exception {
-        waitForHealth();
-
         HttpHeaders headers = new HttpHeaders();
         HttpEntity<String> entity = new HttpEntity<String>(headers);
 
         String url = "http://localhost:" + randomServerPort + "/actuator/health/readiness";
 
         ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+
+        waitForHealth();
+        response = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
     }
 
 }

--- a/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/actuate/ReadinessEndpointUpTest.java
+++ b/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/actuate/ReadinessEndpointUpTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @AuthorizationServer
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-public class ReadinessEndpointUpTest {
+public class ReadinessEndpointUpTest extends AbstractActuatorTest {
 
     @LocalServerPort
     private int randomServerPort;
@@ -31,9 +31,12 @@ public class ReadinessEndpointUpTest {
     @Autowired
     private TestRestTemplate restTemplate;
 
-
+    @Autowired
+    private ListJwksHealthIndicator healthIndicator;
     @Test
-    public void testReadiness() {
+    public void testReadiness() throws Exception {
+        waitForHealth();
+
         HttpHeaders headers = new HttpHeaders();
         HttpEntity<String> entity = new HttpEntity<String>(headers);
 

--- a/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/rest/GreetingControllerUnauthenticatedWhitelist1Test.java
+++ b/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/rest/GreetingControllerUnauthenticatedWhitelist1Test.java
@@ -1,6 +1,7 @@
 package org.entur.jwt.spring.rest;
 
 import org.entur.jwt.junit5.AuthorizationServer;
+import org.entur.jwt.spring.actuate.AbstractActuatorTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,7 +24,7 @@ import java.time.Duration;
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = {"entur.authorization.permit-all.matcher.patterns=/actuator/health,/unprotected/**"})
-public class GreetingControllerUnauthenticatedWhitelist1Test {
+public class GreetingControllerUnauthenticatedWhitelist1Test extends AbstractActuatorTest {
 
     @Autowired
     private WebTestClient webTestClient;
@@ -55,7 +56,8 @@ public class GreetingControllerUnauthenticatedWhitelist1Test {
     }
 
     @Test
-    public void testActuatorOnWhitelist() {
+    public void testActuatorOnWhitelist() throws Exception {
+        waitForHealth();
         webTestClient
             .get()
             .uri("/actuator/health")

--- a/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/rest/GreetingControllerUnauthenticatedWhitelist1Test.java
+++ b/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/rest/GreetingControllerUnauthenticatedWhitelist1Test.java
@@ -57,6 +57,12 @@ public class GreetingControllerUnauthenticatedWhitelist1Test extends AbstractAct
 
     @Test
     public void testActuatorOnWhitelist() throws Exception {
+        webTestClient
+                .get()
+                .uri("/actuator/health")
+                .exchange()
+                .expectStatus().is5xxServerError();
+
         waitForHealth();
         webTestClient
             .get()

--- a/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/rest/PermitAllAnyHttpMethodPatternTest.java
+++ b/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/rest/PermitAllAnyHttpMethodPatternTest.java
@@ -1,6 +1,7 @@
 package org.entur.jwt.spring.rest;
 
 import org.entur.jwt.junit5.AuthorizationServer;
+import org.entur.jwt.spring.actuate.AbstractActuatorTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -11,7 +12,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 @AuthorizationServer
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = {"entur.authorization.permit-all.matcher.patterns=/actuator/**,/unprotected/path/{pathVariable}"})
-public class PermitAllAnyHttpMethodPatternTest {
+public class PermitAllAnyHttpMethodPatternTest extends AbstractActuatorTest {
 
     @Autowired
     private WebTestClient webTestClient;
@@ -26,7 +27,9 @@ public class PermitAllAnyHttpMethodPatternTest {
     }
 
     @Test
-    public void testActuatorOnWhitelist() {
+    public void testActuatorOnWhitelist() throws Exception {
+        waitForHealth();
+
         webTestClient
             .get()
             .uri("/actuator/health")

--- a/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/rest/PermitAllAnyHttpMethodPatternTest.java
+++ b/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/rest/PermitAllAnyHttpMethodPatternTest.java
@@ -28,6 +28,12 @@ public class PermitAllAnyHttpMethodPatternTest extends AbstractActuatorTest {
 
     @Test
     public void testActuatorOnWhitelist() throws Exception {
+        webTestClient
+                .get()
+                .uri("/actuator/health")
+                .exchange()
+                .expectStatus().is5xxServerError();
+
         waitForHealth();
 
         webTestClient

--- a/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/rest/PermitAllGetHttpMethodPatternTest.java
+++ b/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/rest/PermitAllGetHttpMethodPatternTest.java
@@ -30,6 +30,12 @@ public class PermitAllGetHttpMethodPatternTest extends AbstractActuatorTest {
 
     @Test
     public void testActuatorOnWhitelist() throws Exception {
+        webTestClient
+                .get()
+                .uri("/actuator/health")
+                .exchange()
+                .expectStatus().is5xxServerError();
+
         waitForHealth();
 
         webTestClient

--- a/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/rest/PermitAllGetHttpMethodPatternTest.java
+++ b/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/rest/PermitAllGetHttpMethodPatternTest.java
@@ -2,6 +2,7 @@ package org.entur.jwt.spring.rest;
 
 
 import org.entur.jwt.junit5.AuthorizationServer;
+import org.entur.jwt.spring.actuate.AbstractActuatorTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -13,7 +14,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
 @AuthorizationServer
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = {"entur.authorization.permit-all.matcher.method.get.patterns=/actuator/**,/unprotected/path/{pathVariable}"})
-public class PermitAllGetHttpMethodPatternTest {
+public class PermitAllGetHttpMethodPatternTest extends AbstractActuatorTest {
 
     @Autowired
     private WebTestClient webTestClient;
@@ -28,7 +29,9 @@ public class PermitAllGetHttpMethodPatternTest {
     }
 
     @Test
-    public void testActuatorOnWhitelist() {
+    public void testActuatorOnWhitelist() throws Exception {
+        waitForHealth();
+
         webTestClient
             .get()
             .uri("/actuator/health")


### PR DESCRIPTION
We are seeing some slow-to-refresh JWTs and JWKs and want to make health checks more robust + informative.

 - foreground -> background refresh
   - ignore refresh if there is already a previous refresh in progress
   - simpler multi-threading than before
 - more logging, including refresh duration
 - adjust tests correspondingly

Could be improved
 - health lists do not transition to healthy untill next probe visit
   - should not be a problem as the next probe will see the right result, time between probes usually short
 - JWKs and JWTs health are still implemented a bit differently   
