### PR TITLE
Adjust grpc error log levels

### DIFF
--- a/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/AbstractConfigurableLogger.java
+++ b/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/AbstractConfigurableLogger.java
@@ -1,0 +1,105 @@
+package org.entur.jwt.spring;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+import java.util.function.BiConsumer;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+
+import static org.slf4j.event.EventConstants.DEBUG_INT;
+import static org.slf4j.event.EventConstants.ERROR_INT;
+import static org.slf4j.event.EventConstants.INFO_INT;
+import static org.slf4j.event.EventConstants.TRACE_INT;
+import static org.slf4j.event.EventConstants.WARN_INT;
+
+public abstract class AbstractConfigurableLogger {
+
+    protected BooleanSupplier enabled;
+    protected BiConsumer<String, Throwable> logger;
+
+    public AbstractConfigurableLogger(String loggerName, String levelName, boolean stackTrace) {
+        this(LoggerFactory.getLogger(loggerName), parseLevel(levelName), stackTrace);
+    }
+
+    public AbstractConfigurableLogger(Logger logger, Level level, boolean stackTrace) {
+        this.enabled = logEnabledToBooleanSupplier(level, logger);
+        if(stackTrace) {
+            this.logger = loggerToBiConsumer(level, logger);
+        } else {
+            Consumer<String> stringConsumer = loggerToConsumer(level, logger);
+            this.logger = (s, t) -> stringConsumer.accept(s);
+        }
+    }
+
+    protected BooleanSupplier logEnabledToBooleanSupplier(Level level, Logger logger) {
+        int levelInt = level.toInt();
+        switch (levelInt) {
+            case (TRACE_INT):
+                return logger::isTraceEnabled;
+            case (DEBUG_INT):
+                return logger::isDebugEnabled;
+            case (INFO_INT):
+                return logger::isInfoEnabled;
+            case (WARN_INT):
+                return logger::isWarnEnabled;
+            case (ERROR_INT):
+                return logger::isErrorEnabled;
+            default:
+                throw new IllegalStateException("Level [" + level + "] not recognized.");
+        }
+    }
+
+    protected BiConsumer<String, Throwable> loggerToBiConsumer(Level level, Logger logger) {
+
+        int levelInt = level.toInt();
+        switch (levelInt) {
+            case (TRACE_INT):
+                return logger::trace;
+            case (DEBUG_INT):
+                return  logger::debug;
+            case (INFO_INT):
+                return logger::info;
+            case (WARN_INT):
+                return  logger::warn;
+            case (ERROR_INT):
+                return logger::error;
+            default:
+                throw new IllegalStateException("Level [" + level + "] not recognized.");
+        }
+    }
+
+    protected Consumer<String> loggerToConsumer(Level level, Logger logger) {
+
+        int levelInt = level.toInt();
+        switch (levelInt) {
+            case (TRACE_INT):
+                return logger::trace;
+            case (DEBUG_INT):
+                return  logger::debug;
+            case (INFO_INT):
+                return logger::info;
+            case (WARN_INT):
+                return  logger::warn;
+            case (ERROR_INT):
+                return logger::error;
+            default:
+                throw new IllegalStateException("Level [" + level + "] not recognized.");
+        }
+    }
+
+
+    public static Level parseLevel(String loggerLevel) {
+        switch (loggerLevel.toLowerCase()) {
+            case "trace": return Level.TRACE;
+            case "debug": return Level.DEBUG;
+            case "info": return Level.INFO;
+            case "warn": return Level.WARN;
+            case "error": return Level.ERROR;
+            default : {
+                throw new IllegalStateException("Unknown logger level " + loggerLevel);
+            }
+        }
+    }
+}

--- a/jwt-server/spring/jwt-spring-grpc/src/main/java/org/entur/jwt/spring/grpc/GrpcAutoConfiguration.java
+++ b/jwt-server/spring/jwt-spring-grpc/src/main/java/org/entur/jwt/spring/grpc/GrpcAutoConfiguration.java
@@ -250,7 +250,7 @@ public class GrpcAutoConfiguration {
             private static final org.slf4j.Logger log =
                     org.slf4j.LoggerFactory.getLogger(StatusErrorHandler.class);
 
-            public StatusErrorHandler(GrpcExceptionHandlers grpcExceptionHandlers) {
+            public StatusErrorHandler() {
                 super();
 
             }
@@ -283,7 +283,7 @@ public class GrpcAutoConfiguration {
                 super();
 
                 GrpcException grpcException = grpcExceptionHandlers.find(AccessDeniedException.class);
-                this.logger = new GrpcErrorLogger(DefaultAuthErrorHandlerConfiguration.class.getName(), grpcException.getLog().getLevel(), grpcException.getLog().isStackTrace());
+                this.logger = new GrpcErrorLogger(DefaultAccessDeniedErrorHandler.class.getName(), grpcException.getLog().getLevel(), grpcException.getLog().isStackTrace());
             }
 
             @GRpcExceptionHandler

--- a/jwt-server/spring/jwt-spring-grpc/src/main/java/org/entur/jwt/spring/grpc/GrpcAutoConfiguration.java
+++ b/jwt-server/spring/jwt-spring-grpc/src/main/java/org/entur/jwt/spring/grpc/GrpcAutoConfiguration.java
@@ -10,15 +10,15 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import org.entur.jwt.spring.*;
 import org.entur.jwt.spring.grpc.annotate.ConditionalOnMissingErrorHandlerForExactException;
+import org.entur.jwt.spring.grpc.properties.GrpcException;
+import org.entur.jwt.spring.grpc.properties.GrpcExceptionHandlers;
 import org.entur.jwt.spring.grpc.properties.GrpcPermitAll;
 import org.entur.jwt.spring.grpc.properties.GrpcServicesConfiguration;
 import org.entur.jwt.spring.grpc.properties.ServiceMatcherConfiguration;
 import org.entur.jwt.spring.properties.Auth0Flavour;
 import org.entur.jwt.spring.properties.Flavours;
 import org.entur.jwt.spring.properties.KeycloakFlavour;
-import org.lognet.springboot.grpc.GRpcErrorHandler;
 import org.lognet.springboot.grpc.autoconfigure.security.SecurityAutoConfiguration;
-import org.lognet.springboot.grpc.recovery.ErrorHandlerAdapter;
 import org.lognet.springboot.grpc.recovery.GRpcExceptionHandler;
 import org.lognet.springboot.grpc.recovery.GRpcExceptionScope;
 import org.lognet.springboot.grpc.recovery.GRpcServiceAdvice;
@@ -52,13 +52,15 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 @Configuration
-@EnableConfigurationProperties({GrpcPermitAll.class, Flavours.class})
+@EnableConfigurationProperties({GrpcPermitAll.class, Flavours.class, GrpcExceptionHandlers.class})
 @AutoConfigureAfter(value = {JwtAutoConfiguration.class})
 @AutoConfigureBefore(value = {org.lognet.springboot.grpc.autoconfigure.GRpcAutoConfiguration.class, SecurityAutoConfiguration.class})
 public class GrpcAutoConfiguration {
+
+    // TODO spring factory for all sort of exception handling logging
+    // currently we only support two types
 
     private static Logger log = LoggerFactory.getLogger(GrpcAutoConfiguration.class);
 
@@ -209,9 +211,15 @@ public class GrpcAutoConfiguration {
     static class DefaultAuthErrorHandlerConfiguration {
 
         @GRpcServiceAdvice
-        public static class DefaultAuthErrorHandler extends ErrorHandlerAdapter {
-            public DefaultAuthErrorHandler(Optional<GRpcErrorHandler> errorHandler) {
-                super(errorHandler);
+        public static class DefaultAuthErrorHandler {
+
+            private GrpcErrorLogger logger;
+
+            public DefaultAuthErrorHandler(GrpcExceptionHandlers grpcExceptionHandlers) {
+                super();
+
+                GrpcException grpcException = grpcExceptionHandlers.find(AuthenticationException.class);
+                this.logger = new GrpcErrorLogger(DefaultAuthErrorHandler.class.getName(), grpcException.getLog().getLevel(), grpcException.getLog().isStackTrace());
             }
 
             @GRpcExceptionHandler
@@ -221,11 +229,15 @@ public class GrpcAutoConfiguration {
                     if (cause1 instanceof JwtException) {
                         Throwable cause2 = cause1.getCause();
                         if (cause2 instanceof KeySourceException) {
-                            return handle(e, Status.UNAVAILABLE, scope);
+                            logger.handle(e, Status.UNAVAILABLE, scope);
+
+                            return Status.UNAVAILABLE.withDescription(e.getMessage());
                         }
                     }
                 }
-                return handle(e, Status.UNAUTHENTICATED, scope);
+                logger.handle(e, Status.UNAUTHENTICATED, scope);
+
+                return Status.UNAUTHENTICATED.withDescription(e.getMessage());
             }
         }
     }
@@ -234,14 +246,26 @@ public class GrpcAutoConfiguration {
     @Configuration
     static class DefaultStatusErrorHandlerConfiguration {
         @GRpcServiceAdvice
-        public static class StatusErrorHandler extends ErrorHandlerAdapter {
-            public StatusErrorHandler(Optional<GRpcErrorHandler> errorHandler) {
-                super(errorHandler);
+        public static class StatusErrorHandler {
+            private static final org.slf4j.Logger log =
+                    org.slf4j.LoggerFactory.getLogger(StatusErrorHandler.class);
+
+            public StatusErrorHandler(GrpcExceptionHandlers grpcExceptionHandlers) {
+                super();
+
             }
 
             @GRpcExceptionHandler
             public Status handle(StatusRuntimeException e, GRpcExceptionScope scope) {
-                return handle(e, e.getStatus(), scope);
+
+                Status status = e.getStatus();
+                if(status == Status.INTERNAL) {
+                    log.error("Got error with status " + status.getCode().name(), e);
+                } else {
+                    log.info("Got error with status " + status.getCode().name(), e);
+                }
+
+                return status.withDescription(e.getMessage());
             }
         }
     }
@@ -251,18 +275,22 @@ public class GrpcAutoConfiguration {
     static class DefaultAccessDeniedErrorHandlerConfig {
 
         @GRpcServiceAdvice
-        public static class DefaultAccessDeniedErrorHandler extends ErrorHandlerAdapter {
-            @java.lang.SuppressWarnings("all")
-            private static final org.slf4j.Logger log =
-                    org.slf4j.LoggerFactory.getLogger(DefaultAccessDeniedErrorHandler.class);
+        public static class DefaultAccessDeniedErrorHandler {
 
-            public DefaultAccessDeniedErrorHandler(Optional<GRpcErrorHandler> errorHandler) {
-                super(errorHandler);
+            private GrpcErrorLogger logger;
+            @java.lang.SuppressWarnings("all")
+            public DefaultAccessDeniedErrorHandler(GrpcExceptionHandlers grpcExceptionHandlers) {
+                super();
+
+                GrpcException grpcException = grpcExceptionHandlers.find(AccessDeniedException.class);
+                this.logger = new GrpcErrorLogger(DefaultAuthErrorHandlerConfiguration.class.getName(), grpcException.getLog().getLevel(), grpcException.getLog().isStackTrace());
             }
 
             @GRpcExceptionHandler
             public Status handle(AccessDeniedException e, GRpcExceptionScope scope) {
-                return handle(e, Status.PERMISSION_DENIED, scope);
+                logger.handle(e, Status.PERMISSION_DENIED, scope);
+
+                return Status.PERMISSION_DENIED.withDescription(e.getMessage());
             }
         }
     }

--- a/jwt-server/spring/jwt-spring-grpc/src/main/java/org/entur/jwt/spring/grpc/GrpcErrorLogger.java
+++ b/jwt-server/spring/jwt-spring-grpc/src/main/java/org/entur/jwt/spring/grpc/GrpcErrorLogger.java
@@ -1,0 +1,25 @@
+package org.entur.jwt.spring.grpc;
+
+import io.grpc.Status;
+import org.entur.jwt.spring.AbstractConfigurableLogger;
+import org.lognet.springboot.grpc.recovery.GRpcExceptionScope;
+import org.slf4j.Logger;
+import org.slf4j.event.Level;
+
+public class GrpcErrorLogger extends AbstractConfigurableLogger {
+
+
+    public GrpcErrorLogger(String loggerName, String levelName, boolean stackTrace) {
+        super(loggerName, levelName, stackTrace);
+    }
+
+    public GrpcErrorLogger(Logger logger, Level level, boolean stackTrace) {
+        super(logger, level, stackTrace);
+    }
+
+    public void handle(Exception e, Status status, GRpcExceptionScope scope) {
+        if(enabled.getAsBoolean()) {
+            logger.accept("Got error with status " + status.getCode().name(), e);
+        }
+    }
+}

--- a/jwt-server/spring/jwt-spring-grpc/src/main/java/org/entur/jwt/spring/grpc/properties/GrpcException.java
+++ b/jwt-server/spring/jwt-spring-grpc/src/main/java/org/entur/jwt/spring/grpc/properties/GrpcException.java
@@ -1,0 +1,23 @@
+package org.entur.jwt.spring.grpc.properties;
+
+public class GrpcException {
+
+    private String name;
+    private GrpcExceptionLog log = new GrpcExceptionLog();
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public GrpcExceptionLog getLog() {
+        return log;
+    }
+
+    public void setLog(GrpcExceptionLog log) {
+        this.log = log;
+    }
+}

--- a/jwt-server/spring/jwt-spring-grpc/src/main/java/org/entur/jwt/spring/grpc/properties/GrpcExceptionHandlers.java
+++ b/jwt-server/spring/jwt-spring-grpc/src/main/java/org/entur/jwt/spring/grpc/properties/GrpcExceptionHandlers.java
@@ -1,0 +1,45 @@
+package org.entur.jwt.spring.grpc.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ConfigurationProperties(prefix = "entur.jwt.exception-handlers")
+public class GrpcExceptionHandlers {
+
+    private List<GrpcException> grpc = new ArrayList<>();
+
+    public GrpcExceptionHandlers() {
+        // populate default here
+        // a little cumbersome but does not restrict the api later
+
+        GrpcException statusAccessDeniedException = new GrpcException();
+        statusAccessDeniedException.setName(AccessDeniedException.class.getName());
+
+        GrpcException statusAuthenticationException = new GrpcException();
+        statusAuthenticationException.setName(AuthenticationException.class.getName());
+
+        grpc.add(statusAuthenticationException);
+        grpc.add(statusAccessDeniedException);
+    }
+
+    public List<GrpcException> getGrpc() {
+        return grpc;
+    }
+
+    public void setGrpc(List<GrpcException> grpc) {
+        this.grpc = grpc;
+    }
+
+    public GrpcException find(Class c) {
+        for(GrpcException e : grpc) {
+            if(e.getName().equals(c.getName())) {
+                return e;
+            }
+        }
+        return null;
+    }
+}

--- a/jwt-server/spring/jwt-spring-grpc/src/main/java/org/entur/jwt/spring/grpc/properties/GrpcExceptionLog.java
+++ b/jwt-server/spring/jwt-spring-grpc/src/main/java/org/entur/jwt/spring/grpc/properties/GrpcExceptionLog.java
@@ -1,0 +1,23 @@
+package org.entur.jwt.spring.grpc.properties;
+
+public class GrpcExceptionLog {
+
+    private String level = "info";
+    private boolean stackTrace = true;
+
+    public String getLevel() {
+        return level;
+    }
+
+    public void setLevel(String level) {
+        this.level = level;
+    }
+
+    public boolean isStackTrace() {
+        return stackTrace;
+    }
+
+    public void setStackTrace(boolean stackTrace) {
+        this.stackTrace = stackTrace;
+    }
+}


### PR DESCRIPTION
Make log levels configurable for auth related errors, default to error for INTERNAL status runtime exception, otherwise info level.

Log output manually testet via existing using tests.