### PR TITLE
Return gRPC unauthenticated instead of permission denied

### DIFF
--- a/jwt-server/spring/jwt-spring-grpc-ecosystem/src/main/java/org/entur/jwt/spring/grpc/ecosystem/GrpcEcosystemAutoConfiguration.java
+++ b/jwt-server/spring/jwt-spring-grpc-ecosystem/src/main/java/org/entur/jwt/spring/grpc/ecosystem/GrpcEcosystemAutoConfiguration.java
@@ -104,7 +104,7 @@ public class GrpcEcosystemAutoConfiguration {
         AccessPredicate defaultAccessPredicate = AccessPredicate.fullyAuthenticated();
 
         if (!permitAllMappings.isEmpty()) {
-            defaultAccessPredicate = new MustBePermitAllAnonymousAccessPredicate(permitAllMappings);
+            defaultAccessPredicate = new MustBePermitAllAnonymousOrFullyAuthenticatedAccessPredicate(permitAllMappings);
         }
 
         source.setDefault(defaultAccessPredicate);

--- a/jwt-server/spring/jwt-spring-grpc-ecosystem/src/main/java/org/entur/jwt/spring/grpc/ecosystem/MustBePermitAllAnonymousAccessPredicate.java
+++ b/jwt-server/spring/jwt-spring-grpc-ecosystem/src/main/java/org/entur/jwt/spring/grpc/ecosystem/MustBePermitAllAnonymousAccessPredicate.java
@@ -8,11 +8,11 @@ import org.springframework.security.core.Authentication;
 import java.util.List;
 import java.util.Map;
 
-public class GrpcAnonymousAccessPredicate implements AccessPredicate {
+public class MustBePermitAllAnonymousAccessPredicate implements AccessPredicate {
 
     protected final Map<String, List<String>> serviceNameMethodName;
 
-    public GrpcAnonymousAccessPredicate(Map<String, List<String>> serviceNameMethodName) {
+    public MustBePermitAllAnonymousAccessPredicate(Map<String, List<String>> serviceNameMethodName) {
         this.serviceNameMethodName = serviceNameMethodName;
     }
 

--- a/jwt-server/spring/jwt-spring-grpc-ecosystem/src/main/java/org/entur/jwt/spring/grpc/ecosystem/MustBePermitAllAnonymousAuthenticationReader.java
+++ b/jwt-server/spring/jwt-spring-grpc-ecosystem/src/main/java/org/entur/jwt/spring/grpc/ecosystem/MustBePermitAllAnonymousAuthenticationReader.java
@@ -1,0 +1,56 @@
+package org.entur.jwt.spring.grpc.ecosystem;
+
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import net.devh.boot.grpc.server.security.authentication.AnonymousAuthenticationReader;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class MustBePermitAllAnonymousAuthenticationReader extends AnonymousAuthenticationReader {
+
+    protected final Map<String, List<String>> serviceNameMethodName;
+
+    public MustBePermitAllAnonymousAuthenticationReader(String key, Map<String, List<String>> serviceNameMethodName) {
+        super(key);
+        this.serviceNameMethodName = serviceNameMethodName;
+    }
+
+    public MustBePermitAllAnonymousAuthenticationReader(String key, Object principal, Collection<? extends GrantedAuthority> authorities, Map<String, List<String>> serviceNameMethodName) {
+        super(key, principal, authorities);
+        this.serviceNameMethodName = serviceNameMethodName;
+    }
+
+    @Override
+    public Authentication readAuthentication(ServerCall<?, ?> call, Metadata headers) {
+        if(acceptAnon(call)) {
+            return super.readAuthentication(call, headers);
+        }
+        throw new AuthenticationCredentialsNotFoundException("Method " + call.getMethodDescriptor().getFullMethodName() + " requires authentication");
+    }
+
+    private boolean acceptAnon(ServerCall<?, ?> call) {
+        MethodDescriptor<?, ?> method = call.getMethodDescriptor();
+
+        String lowerCaseServiceName = method.getServiceName().toLowerCase();
+        List<String> methodNames = serviceNameMethodName.get(lowerCaseServiceName);
+        if (methodNames != null) {
+            if (methodNames.contains("*")) {
+                return true;
+            }
+
+            String lowerCaseBareMethodName = method.getBareMethodName().toLowerCase();
+            String lowerCaseFullMethodName = method.getFullMethodName().toLowerCase();
+
+            if (methodNames.contains(lowerCaseBareMethodName) || methodNames.contains(lowerCaseFullMethodName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/jwt-server/spring/jwt-spring-grpc-ecosystem/src/main/java/org/entur/jwt/spring/grpc/ecosystem/MustBePermitAllAnonymousOrFullyAuthenticatedAccessPredicate.java
+++ b/jwt-server/spring/jwt-spring-grpc-ecosystem/src/main/java/org/entur/jwt/spring/grpc/ecosystem/MustBePermitAllAnonymousOrFullyAuthenticatedAccessPredicate.java
@@ -8,11 +8,11 @@ import org.springframework.security.core.Authentication;
 import java.util.List;
 import java.util.Map;
 
-public class MustBePermitAllAnonymousAccessPredicate implements AccessPredicate {
+public class MustBePermitAllAnonymousOrFullyAuthenticatedAccessPredicate implements AccessPredicate {
 
     protected final Map<String, List<String>> serviceNameMethodName;
 
-    public MustBePermitAllAnonymousAccessPredicate(Map<String, List<String>> serviceNameMethodName) {
+    public MustBePermitAllAnonymousOrFullyAuthenticatedAccessPredicate(Map<String, List<String>> serviceNameMethodName) {
         this.serviceNameMethodName = serviceNameMethodName;
     }
 

--- a/jwt-server/spring/jwt-spring-grpc-ecosystem/src/test/java/org/entur/jwt/spring/grpc/GrpcConfiguration.java
+++ b/jwt-server/spring/jwt-spring-grpc-ecosystem/src/test/java/org/entur/jwt/spring/grpc/GrpcConfiguration.java
@@ -1,0 +1,26 @@
+package org.entur.jwt.spring.grpc;
+
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import net.devh.boot.grpc.server.advice.GrpcAdvice;
+import net.devh.boot.grpc.server.advice.GrpcExceptionHandler;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GrpcConfiguration {
+
+    // add advice so that the error handler interceptor is also added
+
+    @GrpcAdvice
+    public static class StatusRuntimeExceptionGrpcServiceAdvice {
+        @java.lang.SuppressWarnings("all")
+
+        // this error mapper can be overriden by specifying value in the annotation
+        @GrpcExceptionHandler
+        public Status handle(StatusRuntimeException e) {
+            return e.getStatus();
+        }
+    }
+
+}

--- a/jwt-server/spring/jwt-spring-grpc-ecosystem/src/test/java/org/entur/jwt/spring/grpc/UnauthenticatedTest.java
+++ b/jwt-server/spring/jwt-spring-grpc-ecosystem/src/test/java/org/entur/jwt/spring/grpc/UnauthenticatedTest.java
@@ -22,9 +22,6 @@ import io.grpc.StatusRuntimeException;
 @DirtiesContext
 public class UnauthenticatedTest extends AbstractGrpcTest {
 
-    @LocalServerPort
-    private int randomServerPort;
-    
     @Test 
     public void testProtectedResource() {
         StatusRuntimeException exception = assertThrows(StatusRuntimeException.class, () -> {


### PR DESCRIPTION
 * Convert access denied as to unauthenticated status if anon credentials.
 * Throw unauthenticated as early as possible for anon credentials.
   * Add additional layer of throw `AuthenticationCredentialsNotFoundException` from `AnonymousAuthenticationReader` subclass if method is not white-listed (using PermitAll). 

Anon requests must now pass through two controls before being let in:

 * `MustBePermitAllAnonymousAuthenticationReader` when creating the intermediate authentication
 * `MustBePermitAllAnonymousAccessPredicate` via `ManualGrpcSecurityMetadataSource` voter via `AuthenticationManager`