### PR TITLE
Potential fix for code scanning alert no. 3: Log Injection

### DIFF
--- a/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/rest/GreetingController.java
+++ b/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/rest/GreetingController.java
@@ -46,8 +46,8 @@ public class GreetingController {
 
     @GetMapping("/unprotected/path/{pathVariable}")
     public Mono<Greeting> unprotectedWithPathVariable(@PathVariable("pathVariable") String value) {
-        // Sanitize user input to prevent log injection by removing all control characters
-        String sanitizedValue = value.replaceAll("[\\p{Cntrl}]", "");
+        // Sanitize user input to prevent log injection by removing all control characters and line breaks
+        String sanitizedValue = value.replaceAll("[\\p{Cntrl}\\r\\n\\u2028\\u2029]", "");
         log.info("Get unprotected method with path variable [user input: '{}']", sanitizedValue);
 
         return Mono.just(new Greeting(counter.incrementAndGet(), "Hello unprotected with path variable " + sanitizedValue));

--- a/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/rest/GreetingController.java
+++ b/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/rest/GreetingController.java
@@ -46,9 +46,11 @@ public class GreetingController {
 
     @GetMapping("/unprotected/path/{pathVariable}")
     public Mono<Greeting> unprotectedWithPathVariable(@PathVariable("pathVariable") String value) {
-        log.info("Get unprotected method with path variable " + value);
+        // Sanitize user input to prevent log injection
+        String sanitizedValue = value.replaceAll("[\\r\\n]", "");
+        log.info("Get unprotected method with path variable {}", sanitizedValue);
 
-        return Mono.just(new Greeting(counter.incrementAndGet(), "Hello unprotected with path variable " + value));
+        return Mono.just(new Greeting(counter.incrementAndGet(), "Hello unprotected with path variable " + sanitizedValue));
     }
 
     @GetMapping("/protected")

--- a/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/rest/GreetingController.java
+++ b/jwt-server/spring/jwt-spring-webflux/src/test/java/org/entur/jwt/spring/rest/GreetingController.java
@@ -46,9 +46,9 @@ public class GreetingController {
 
     @GetMapping("/unprotected/path/{pathVariable}")
     public Mono<Greeting> unprotectedWithPathVariable(@PathVariable("pathVariable") String value) {
-        // Sanitize user input to prevent log injection
-        String sanitizedValue = value.replaceAll("[\\r\\n]", "");
-        log.info("Get unprotected method with path variable {}", sanitizedValue);
+        // Sanitize user input to prevent log injection by removing all control characters
+        String sanitizedValue = value.replaceAll("[\\p{Cntrl}]", "");
+        log.info("Get unprotected method with path variable [user input: '{}']", sanitizedValue);
 
         return Mono.just(new Greeting(counter.incrementAndGet(), "Hello unprotected with path variable " + sanitizedValue));
     }


### PR DESCRIPTION
Potential fix for [https://github.com/entur/jwt-resource-server/security/code-scanning/3](https://github.com/entur/jwt-resource-server/security/code-scanning/3)

To fix the log injection vulnerability, we need to sanitize the user-provided input before logging it. The simplest and most effective way is to remove any newline (`\n`, `\r`) and other control characters from the `value` string before including it in the log message. This can be done using `String.replaceAll()` with a regular expression that matches these characters. Additionally, it's best practice to use parameterized logging (i.e., `log.info("... {}", value)`) rather than string concatenation, to further reduce the risk of injection and improve log parsing. The required changes are in the `unprotectedWithPathVariable` method in `GreetingController.java`, specifically on line 49. No new imports are needed, as the required methods are part of the Java standard library.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
