### PR TITLE
Cache decoded JWTs

### DIFF
--- a/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/JwkSourceMap.java
+++ b/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/JwkSourceMap.java
@@ -2,6 +2,7 @@ package org.entur.jwt.spring;
 
 import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
+import org.entur.jwt.spring.actuate.ListEventListener;
 import org.springframework.beans.factory.DisposableBean;
 
 import java.io.Closeable;
@@ -11,9 +12,11 @@ import java.util.Map;
 public class JwkSourceMap<C extends SecurityContext> implements Closeable, DisposableBean {
 
     private final Map<String, JWKSource<C>> jwkSources;
+    private final Map<String, ListEventListener> jwkEventListeners;
 
-    public JwkSourceMap(Map<String, JWKSource<C>> jwkSources) {
+    public JwkSourceMap(Map<String, JWKSource<C>> jwkSources, Map<String, ListEventListener> jwkEventListeners) {
         this.jwkSources = jwkSources;
+        this.jwkEventListeners = jwkEventListeners;
     }
 
     @Override
@@ -35,5 +38,9 @@ public class JwkSourceMap<C extends SecurityContext> implements Closeable, Dispo
     @Override
     public void destroy() throws Exception {
         close();
+    }
+
+    public Map<String, ListEventListener> getJwkEventListeners() {
+        return jwkEventListeners;
     }
 }

--- a/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/JwkSourceMapFactory.java
+++ b/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/JwkSourceMapFactory.java
@@ -7,6 +7,7 @@ import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jose.util.DefaultResourceRetriever;
 import org.entur.jwt.spring.actuate.DefaultJwksHealthIndicator;
 import org.entur.jwt.spring.actuate.JwkSetSourceEventListener;
+import org.entur.jwt.spring.actuate.ListEventListener;
 import org.entur.jwt.spring.actuate.ListJwksHealthIndicator;
 import org.entur.jwt.spring.properties.jwk.JwkCacheProperties;
 import org.entur.jwt.spring.properties.jwk.JwkLocationProperties;
@@ -28,9 +29,9 @@ public class JwkSourceMapFactory<C> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JwkSourceMapFactory.class);
 
-
     public JwkSourceMap getJwkSourceMap(Map<String, JwtTenantProperties> tenants, JwkProperties jwkConfiguration, ListJwksHealthIndicator listJwksHealthIndicator) {
         Map<String, JWKSource> jwkSources = new HashMap<>();
+        Map<String, ListEventListener> jwkEventListeners = new HashMap<>();
 
         for (Map.Entry<String, JwtTenantProperties> entry : tenants.entrySet()) {
             JwtTenantProperties tenantConfiguration = entry.getValue();
@@ -55,7 +56,8 @@ public class JwkSourceMapFactory<C> {
                 throw new IllegalArgumentException("Invalid location " + tenantJwkConfiguration.getLocation() + " for " + entry.getKey());
             }
 
-            JwkSetSourceEventListener eventListener = new JwkSetSourceEventListener(entry.getKey());
+            ListEventListener eventListener  = new ListEventListener();
+            eventListener.addEventListener(new JwkSetSourceEventListener(entry.getKey()));
 
             int connectTimeout = jwkConfiguration.getConnectTimeout();
             int readTimeout = jwkConfiguration.getReadTimeout();
@@ -121,9 +123,10 @@ public class JwkSourceMapFactory<C> {
             }
 
             jwkSources.put(tenantConfiguration.getIssuer(), jwkSource);
+            jwkEventListeners.put(tenantConfiguration.getIssuer(), eventListener);
         }
 
-        return new JwkSourceMap(jwkSources);
+        return new JwkSourceMap(jwkSources, jwkEventListeners);
     }
 
 

--- a/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/actuate/ListEventListener.java
+++ b/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/actuate/ListEventListener.java
@@ -1,0 +1,26 @@
+package org.entur.jwt.spring.actuate;
+
+import com.nimbusds.jose.util.events.Event;
+import com.nimbusds.jose.util.events.EventListener;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class ListEventListener implements EventListener {
+
+    private List<EventListener> eventListeners = Collections.emptyList();
+
+    public void addEventListener(EventListener eventListener) {
+        List<EventListener> newEventListeners = new ArrayList<>(eventListeners);
+        newEventListeners.add(eventListener);
+        this.eventListeners = newEventListeners;
+    }
+
+    @Override
+    public void notify(Event event) {
+        for (EventListener eventListener : eventListeners) {
+            eventListener.notify(event);
+        }
+    }
+}

--- a/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/cache/DecodedJwtCacheConfigurationReader.java
+++ b/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/cache/DecodedJwtCacheConfigurationReader.java
@@ -1,0 +1,32 @@
+package org.entur.jwt.spring.cache;
+
+import org.entur.jwt.spring.properties.JwtProperties;
+import org.entur.jwt.spring.properties.jwk.JwkCacheProperties;
+import org.entur.jwt.spring.properties.jwk.JwtTenantProperties;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class DecodedJwtCacheConfigurationReader {
+
+    public static Set<String> convert(JwtProperties jwt) {
+        JwkCacheProperties cache = jwt.getJwk().getCache();
+        boolean decodedJwtCache = cache.isEnabled() && cache.getPreemptive().isEnabled() && cache.getPreemptive().getEager().isEnabled();
+
+        Set<String> decodedJwtCacheIssuers;
+        if(decodedJwtCache) {
+            decodedJwtCacheIssuers = new HashSet<>();
+            for (Map.Entry<String, JwtTenantProperties> entry : jwt.getTenants().entrySet()) {
+                JwtTenantProperties value = entry.getValue();
+                if(value.isEnabled() && value.getDecoderCache().isEnabled()) {
+                    decodedJwtCacheIssuers.add(entry.getKey());
+                }
+            }
+        } else {
+            decodedJwtCacheIssuers = Collections.emptySet();
+        }
+        return decodedJwtCacheIssuers;
+    }
+}

--- a/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/cache/DecodedJwtCacheJwtDecoder.java
+++ b/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/cache/DecodedJwtCacheJwtDecoder.java
@@ -2,9 +2,8 @@ package org.entur.jwt.spring.cache;
 
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
-import com.nimbusds.jose.jwk.source.AbstractJWKSetSourceEvent;
 import com.nimbusds.jose.jwk.source.CachingJWKSetSource;
-import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jose.jwk.source.JWKSetSource;
 import com.nimbusds.jose.util.events.Event;
 import com.nimbusds.jose.util.events.EventListener;
 import org.springframework.security.oauth2.core.OAuth2Error;
@@ -38,7 +37,10 @@ public class DecodedJwtCacheJwtDecoder implements JwtDecoder, EventListener {
 
     protected Map<String, Jwt> cache = new ConcurrentHashMap<>();
 
-    public DecodedJwtCacheJwtDecoder(JwtDecoder delegate, OAuth2TokenValidator<Jwt> jwtValidators) {
+    protected volatile boolean writeEnabled = false;
+    protected volatile boolean readEnabled = false;
+
+    public  DecodedJwtCacheJwtDecoder(JwtDecoder delegate, OAuth2TokenValidator<Jwt> jwtValidators) {
         this.delegate = delegate;
         this.jwtValidator = jwtValidators;
     }
@@ -46,13 +48,18 @@ public class DecodedJwtCacheJwtDecoder implements JwtDecoder, EventListener {
     @Override
     public Jwt decode(String token) throws JwtException {
 
-        Jwt cachedJwt = cache.get(token);
-        if(cachedJwt != null) {
-            return validateJwt(cachedJwt);
+        if(readEnabled) {
+            Jwt cachedJwt = cache.get(token);
+            if (cachedJwt != null) {
+                return validateJwt(cachedJwt);
+            }
         }
+
         Jwt jwt = delegate.decode(token);
 
-        cache.put(token, jwt);
+        if(writeEnabled) {
+            cache.put(token, jwt);
+        }
 
         return jwt;
     }
@@ -88,16 +95,23 @@ public class DecodedJwtCacheJwtDecoder implements JwtDecoder, EventListener {
             keyIds.add(key.getKeyID());
         }
 
+        // remove unknown keys
         for (Map.Entry<String, Jwt> entry : cache.entrySet()) {
             Jwt value = entry.getValue();
             if(value != null) {
                 if (!keyIds.contains(value.getHeaders().get("kid"))) {
                     cache.remove(entry.getKey());
-                } else {
-                    OAuth2TokenValidatorResult result = jwtValidator.validate(value);
-                    if (result.hasErrors()) {
-                        cache.remove(entry.getKey());
-                    }
+                }
+            }
+        }
+
+        // remove no longer valid jwts
+        for (Map.Entry<String, Jwt> entry : cache.entrySet()) {
+            Jwt value = entry.getValue();
+            if(value != null) {
+                OAuth2TokenValidatorResult result = jwtValidator.validate(value);
+                if (result.hasErrors()) {
+                    cache.remove(entry.getKey());
                 }
             }
         }
@@ -105,13 +119,23 @@ public class DecodedJwtCacheJwtDecoder implements JwtDecoder, EventListener {
 
     @Override
     public void notify(Event event) {
-        if(event instanceof CachingJWKSetSource.RefreshCompletedEvent<?>) {
+        if(event instanceof CachingJWKSetSource.RefreshInitiatedEvent<?>) {
+            writeEnabled = false;
+        } else if(event instanceof CachingJWKSetSource.RefreshCompletedEvent<?>) {
             CachingJWKSetSource.RefreshCompletedEvent refreshCompletedEvent = (CachingJWKSetSource.RefreshCompletedEvent) event;
             refresh(refreshCompletedEvent.getJWKSet());
+
+            CachingJWKSetSource source = (CachingJWKSetSource) refreshCompletedEvent.getSource();
+            source.getCacheRefreshTimeout()
+
+            writeEnabled = true;
+            readEnabled = true;
         } else if(event instanceof CachingJWKSetSource.UnableToRefreshEvent<?>) {
-            cache.clear();
+            readEnabled = false;
+            // write only happens if approved by regular flow
         } else if(event instanceof CachingJWKSetSource.RefreshTimedOutEvent<?>) {
-            cache.clear();
+            readEnabled = false;
+            // write only happens if approved by regular flow
         }
     }
 }

--- a/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/cache/DecodedJwtCacheJwtDecoder.java
+++ b/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/cache/DecodedJwtCacheJwtDecoder.java
@@ -2,7 +2,9 @@ package org.entur.jwt.spring.cache;
 
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.source.AbstractJWKSetSourceEvent;
 import com.nimbusds.jose.jwk.source.CachingJWKSetSource;
+import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jose.util.events.Event;
 import com.nimbusds.jose.util.events.EventListener;
 import org.springframework.security.oauth2.core.OAuth2Error;
@@ -21,7 +23,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Caching of JWTs.
+ * Caching of validated JWTs.
  *
  * If used, make sure to proactively update JWKs somehow.
  *
@@ -46,10 +48,7 @@ public class DecodedJwtCacheJwtDecoder implements JwtDecoder, EventListener {
 
         Jwt cachedJwt = cache.get(token);
         if(cachedJwt != null) {
-            String issuer = (String) cachedJwt.getClaims().get("iss");
-            if(issuer != null) {
-                return validateJwt(cachedJwt);
-            }
+            return validateJwt(cachedJwt);
         }
         Jwt jwt = delegate.decode(token);
 
@@ -58,7 +57,7 @@ public class DecodedJwtCacheJwtDecoder implements JwtDecoder, EventListener {
         return jwt;
     }
 
-    private Jwt validateJwt(Jwt jwt) {
+    protected Jwt validateJwt(Jwt jwt) {
         OAuth2TokenValidatorResult result = jwtValidator.validate(jwt);
         if (result.hasErrors()) {
             cache.remove(jwt.getTokenValue());
@@ -70,7 +69,7 @@ public class DecodedJwtCacheJwtDecoder implements JwtDecoder, EventListener {
         return jwt;
     }
 
-    private String getJwtValidationExceptionMessage(Collection<OAuth2Error> errors) {
+    protected String getJwtValidationExceptionMessage(Collection<OAuth2Error> errors) {
         for (OAuth2Error oAuth2Error : errors) {
             if (StringUtils.hasLength(oAuth2Error.getDescription())) {
                 return String.format(DECODING_ERROR_MESSAGE_TEMPLATE, oAuth2Error.getDescription());
@@ -109,6 +108,10 @@ public class DecodedJwtCacheJwtDecoder implements JwtDecoder, EventListener {
         if(event instanceof CachingJWKSetSource.RefreshCompletedEvent<?>) {
             CachingJWKSetSource.RefreshCompletedEvent refreshCompletedEvent = (CachingJWKSetSource.RefreshCompletedEvent) event;
             refresh(refreshCompletedEvent.getJWKSet());
+        } else if(event instanceof CachingJWKSetSource.UnableToRefreshEvent<?>) {
+            cache.clear();
+        } else if(event instanceof CachingJWKSetSource.RefreshTimedOutEvent<?>) {
+            cache.clear();
         }
     }
 }

--- a/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/cache/DecodedJwtCacheJwtDecoder.java
+++ b/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/cache/DecodedJwtCacheJwtDecoder.java
@@ -5,6 +5,7 @@ import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.source.CachingJWKSetSource;
 import com.nimbusds.jose.util.events.Event;
 import com.nimbusds.jose.util.events.EventListener;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.oauth2.core.OAuth2Error;
@@ -58,7 +59,7 @@ public class DecodedJwtCacheJwtDecoder implements JwtDecoder, EventListener, Clo
 
     protected long cleanupInterval;
 
-    public  DecodedJwtCacheJwtDecoder(JwtDecoder delegate, OAuth2TokenValidator<Jwt> jwtValidators, long cleanupInterval) {
+    public DecodedJwtCacheJwtDecoder(JwtDecoder delegate, OAuth2TokenValidator<Jwt> jwtValidators, long cleanupInterval) {
         this.delegate = delegate;
         this.jwtValidator = jwtValidators;
         this.cleanupInterval = cleanupInterval;
@@ -68,9 +69,10 @@ public class DecodedJwtCacheJwtDecoder implements JwtDecoder, EventListener, Clo
         scheduledExecutorService.scheduleWithFixedDelay(() -> {
             if(LOGGER.isDebugEnabled()) LOGGER.debug("Cleaning cache");
             try {
-                // should not be any, but a catch all mechanism
+                // should not be any, but a catch-all mechanism
                 cleanCacheForJwtsWithUnknownKeyIds();
 
+                // avoid memory leaks
                 cleanCacheForInvalidJwts();
             } catch (Throwable e) {
                 // ignore, will be handled by regular flow
@@ -126,11 +128,16 @@ public class DecodedJwtCacheJwtDecoder implements JwtDecoder, EventListener, Clo
     }
 
     public void setKeyIds(JWKSet jwtSet) {
+        Set<String> keyIds = convert(jwtSet);
+        this.keyIds = keyIds;
+    }
+
+    private static @NonNull Set<String> convert(JWKSet jwtSet) {
         Set<String> keyIds = new HashSet<>(jwtSet.getKeys().size());
         for (JWK key : jwtSet.getKeys()) {
             keyIds.add(key.getKeyID());
         }
-        this.keyIds = keyIds;
+        return keyIds;
     }
 
     public void cleanCacheForJwtsWithUnknownKeyIds() {
@@ -165,10 +172,13 @@ public class DecodedJwtCacheJwtDecoder implements JwtDecoder, EventListener, Clo
             writeEnabled = false;
         } else if(event instanceof CachingJWKSetSource.RefreshCompletedEvent<?>) {
             CachingJWKSetSource.RefreshCompletedEvent refreshCompletedEvent = (CachingJWKSetSource.RefreshCompletedEvent) event;
-            setKeyIds(refreshCompletedEvent.getJWKSet());
 
-            cleanCacheForJwtsWithUnknownKeyIds();
-            cleanCacheForInvalidJwts();
+            Set<String> keyIds = convert(refreshCompletedEvent.getJWKSet());
+            boolean removed = !keyIds.containsAll(this.keyIds);
+            this.keyIds = keyIds;
+            if(removed) {
+                cleanCacheForJwtsWithUnknownKeyIds();
+            }
 
             readEnabled = true;
             writeEnabled = true;

--- a/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/cache/DecodedJwtCacheJwtDecoder.java
+++ b/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/cache/DecodedJwtCacheJwtDecoder.java
@@ -1,0 +1,114 @@
+package org.entur.jwt.spring.cache;
+
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.source.CachingJWKSetSource;
+import com.nimbusds.jose.util.events.Event;
+import com.nimbusds.jose.util.events.EventListener;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.oauth2.jwt.JwtValidationException;
+import org.springframework.util.StringUtils;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Caching of JWTs.
+ *
+ * If used, make sure to proactively update JWKs somehow.
+ *
+ */
+
+public class DecodedJwtCacheJwtDecoder implements JwtDecoder, EventListener {
+
+    private static final String DECODING_ERROR_MESSAGE_TEMPLATE = "An error occurred while attempting to decode the Jwt: %s";
+
+    protected final JwtDecoder delegate;
+    protected final OAuth2TokenValidator<Jwt> jwtValidator;
+
+    protected Map<String, Jwt> cache = new ConcurrentHashMap<>();
+
+    public DecodedJwtCacheJwtDecoder(JwtDecoder delegate, OAuth2TokenValidator<Jwt> jwtValidators) {
+        this.delegate = delegate;
+        this.jwtValidator = jwtValidators;
+    }
+
+    @Override
+    public Jwt decode(String token) throws JwtException {
+
+        Jwt cachedJwt = cache.get(token);
+        if(cachedJwt != null) {
+            String issuer = (String) cachedJwt.getClaims().get("iss");
+            if(issuer != null) {
+                return validateJwt(cachedJwt);
+            }
+        }
+        Jwt jwt = delegate.decode(token);
+
+        cache.put(token, jwt);
+
+        return jwt;
+    }
+
+    private Jwt validateJwt(Jwt jwt) {
+        OAuth2TokenValidatorResult result = jwtValidator.validate(jwt);
+        if (result.hasErrors()) {
+            cache.remove(jwt.getTokenValue());
+
+            Collection<OAuth2Error> errors = result.getErrors();
+            String validationErrorString = getJwtValidationExceptionMessage(errors);
+            throw new JwtValidationException(validationErrorString, errors);
+        }
+        return jwt;
+    }
+
+    private String getJwtValidationExceptionMessage(Collection<OAuth2Error> errors) {
+        for (OAuth2Error oAuth2Error : errors) {
+            if (StringUtils.hasLength(oAuth2Error.getDescription())) {
+                return String.format(DECODING_ERROR_MESSAGE_TEMPLATE, oAuth2Error.getDescription());
+            }
+        }
+        return "Unable to validate Jwt";
+    }
+
+    public void clear() {
+        cache.clear();
+    }
+
+    public void refresh(JWKSet jwtSet) {
+        Set<String> keyIds = new HashSet<>(jwtSet.getKeys().size());
+        for (JWK key : jwtSet.getKeys()) {
+            keyIds.add(key.getKeyID());
+        }
+
+        for (Map.Entry<String, Jwt> entry : cache.entrySet()) {
+            Jwt value = entry.getValue();
+            if(value != null) {
+                if (!keyIds.contains(value.getHeaders().get("kid"))) {
+                    cache.remove(entry.getKey());
+                } else {
+                    OAuth2TokenValidatorResult result = jwtValidator.validate(value);
+                    if (result.hasErrors()) {
+                        cache.remove(entry.getKey());
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void notify(Event event) {
+        if(event instanceof CachingJWKSetSource.RefreshCompletedEvent<?>) {
+            CachingJWKSetSource.RefreshCompletedEvent refreshCompletedEvent = (CachingJWKSetSource.RefreshCompletedEvent) event;
+            refresh(refreshCompletedEvent.getJWKSet());
+        }
+    }
+}

--- a/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/cache/DecodedJwtCacheJwtDecoder.java
+++ b/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/cache/DecodedJwtCacheJwtDecoder.java
@@ -3,9 +3,10 @@ package org.entur.jwt.spring.cache;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.source.CachingJWKSetSource;
-import com.nimbusds.jose.jwk.source.JWKSetSource;
 import com.nimbusds.jose.util.events.Event;
 import com.nimbusds.jose.util.events.EventListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidatorResult;
@@ -15,11 +16,16 @@ import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.security.oauth2.jwt.JwtValidationException;
 import org.springframework.util.StringUtils;
 
+import java.io.Closeable;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Caching of validated JWTs.
@@ -28,21 +34,49 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  */
 
-public class DecodedJwtCacheJwtDecoder implements JwtDecoder, EventListener {
+public class DecodedJwtCacheJwtDecoder implements JwtDecoder, EventListener, Closeable {
 
     private static final String DECODING_ERROR_MESSAGE_TEMPLATE = "An error occurred while attempting to decode the Jwt: %s";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DecodedJwtCacheJwtDecoder.class);
+
+    public static ScheduledExecutorService createDefaultScheduledExecutorService() {
+        return Executors.newSingleThreadScheduledExecutor();
+    }
+
+    protected ScheduledExecutorService scheduledExecutorService = createDefaultScheduledExecutorService();
 
     protected final JwtDecoder delegate;
     protected final OAuth2TokenValidator<Jwt> jwtValidator;
 
-    protected Map<String, Jwt> cache = new ConcurrentHashMap<>();
+    protected ConcurrentHashMap<String, Jwt> cache = new ConcurrentHashMap<>();
+
+    protected Set<String> keyIds = Collections.emptySet();
 
     protected volatile boolean writeEnabled = false;
     protected volatile boolean readEnabled = false;
 
-    public  DecodedJwtCacheJwtDecoder(JwtDecoder delegate, OAuth2TokenValidator<Jwt> jwtValidators) {
+    protected long cleanupInterval;
+
+    public  DecodedJwtCacheJwtDecoder(JwtDecoder delegate, OAuth2TokenValidator<Jwt> jwtValidators, long cleanupInterval) {
         this.delegate = delegate;
         this.jwtValidator = jwtValidators;
+        this.cleanupInterval = cleanupInterval;
+    }
+
+    public void scheduleCleanup() {
+        scheduledExecutorService.scheduleWithFixedDelay(() -> {
+            if(LOGGER.isDebugEnabled()) LOGGER.debug("Cleaning cache");
+            try {
+                // should not be any, but a catch all mechanism
+                cleanCacheForJwtsWithUnknownKeyIds();
+
+                cleanCacheForInvalidJwts();
+            } catch (Throwable e) {
+                // ignore, will be handled by regular flow
+                LOGGER.warn("Problem cleaning cache", e);
+            }
+        }, cleanupInterval, cleanupInterval, TimeUnit.MILLISECONDS);
     }
 
     @Override
@@ -51,7 +85,9 @@ public class DecodedJwtCacheJwtDecoder implements JwtDecoder, EventListener {
         if(readEnabled) {
             Jwt cachedJwt = cache.get(token);
             if (cachedJwt != null) {
-                return validateJwt(cachedJwt);
+                if(keyIds.contains(cachedJwt.getHeaders().get("kid"))) {
+                    return validateJwt(cachedJwt);
+                }
             }
         }
 
@@ -89,12 +125,15 @@ public class DecodedJwtCacheJwtDecoder implements JwtDecoder, EventListener {
         cache.clear();
     }
 
-    public void refresh(JWKSet jwtSet) {
+    public void setKeyIds(JWKSet jwtSet) {
         Set<String> keyIds = new HashSet<>(jwtSet.getKeys().size());
         for (JWK key : jwtSet.getKeys()) {
             keyIds.add(key.getKeyID());
         }
+        this.keyIds = keyIds;
+    }
 
+    public void cleanCacheForJwtsWithUnknownKeyIds() {
         // remove unknown keys
         for (Map.Entry<String, Jwt> entry : cache.entrySet()) {
             Jwt value = entry.getValue();
@@ -105,7 +144,10 @@ public class DecodedJwtCacheJwtDecoder implements JwtDecoder, EventListener {
             }
         }
 
-        // remove no longer valid jwts
+    }
+
+    protected void cleanCacheForInvalidJwts() {
+        // remove no longer valid JWTs. Typically they expire by time.
         for (Map.Entry<String, Jwt> entry : cache.entrySet()) {
             Jwt value = entry.getValue();
             if(value != null) {
@@ -123,19 +165,23 @@ public class DecodedJwtCacheJwtDecoder implements JwtDecoder, EventListener {
             writeEnabled = false;
         } else if(event instanceof CachingJWKSetSource.RefreshCompletedEvent<?>) {
             CachingJWKSetSource.RefreshCompletedEvent refreshCompletedEvent = (CachingJWKSetSource.RefreshCompletedEvent) event;
-            refresh(refreshCompletedEvent.getJWKSet());
+            setKeyIds(refreshCompletedEvent.getJWKSet());
 
-            CachingJWKSetSource source = (CachingJWKSetSource) refreshCompletedEvent.getSource();
-            source.getCacheRefreshTimeout()
+            cleanCacheForJwtsWithUnknownKeyIds();
+            cleanCacheForInvalidJwts();
 
-            writeEnabled = true;
             readEnabled = true;
+            writeEnabled = true;
         } else if(event instanceof CachingJWKSetSource.UnableToRefreshEvent<?>) {
             readEnabled = false;
-            // write only happens if approved by regular flow
+            // there might still some time left until no JWKs are cached anymore
         } else if(event instanceof CachingJWKSetSource.RefreshTimedOutEvent<?>) {
             readEnabled = false;
-            // write only happens if approved by regular flow
+            // there might still some time left until no JWKs are cached anymore
         }
+    }
+
+    public void close() {
+        scheduledExecutorService.shutdownNow();
     }
 }

--- a/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/properties/jwk/JwtCacheProperties.java
+++ b/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/properties/jwk/JwtCacheProperties.java
@@ -1,0 +1,14 @@
+package org.entur.jwt.spring.properties.jwk;
+
+public class JwtCacheProperties {
+
+    private boolean enabled = false;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/properties/jwk/JwtDecoderCacheProperties.java
+++ b/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/properties/jwk/JwtDecoderCacheProperties.java
@@ -1,0 +1,15 @@
+package org.entur.jwt.spring.properties.jwk;
+
+public class JwtDecoderCacheProperties {
+
+    private boolean enabled = false;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+}

--- a/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/properties/jwk/JwtTenantProperties.java
+++ b/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/properties/jwk/JwtTenantProperties.java
@@ -12,6 +12,8 @@ public class JwtTenantProperties {
 
     protected JwkLocationProperties jwk;
 
+    protected JwtDecoderCacheProperties decoderCache = new JwtDecoderCacheProperties();
+
     protected Map<String, Object> properties = new HashMap<>();
 
     public String getType() {
@@ -54,4 +56,11 @@ public class JwtTenantProperties {
         return properties;
     }
 
+    public void setDecoderCache(JwtDecoderCacheProperties decoderCache) {
+        this.decoderCache = decoderCache;
+    }
+
+    public JwtDecoderCacheProperties getDecoderCache() {
+        return decoderCache;
+    }
 }

--- a/jwt-server/spring/jwt-spring-grpc-native/src/main/java/org/entur/jwt/spring/grpc/netty/CachedIssuerJwtDecoder.java
+++ b/jwt-server/spring/jwt-spring-grpc-native/src/main/java/org/entur/jwt/spring/grpc/netty/CachedIssuerJwtDecoder.java
@@ -1,0 +1,108 @@
+package org.entur.jwt.spring.grpc.netty;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.JWSVerificationKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWT;
+import com.nimbusds.jwt.JWTParser;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+import org.entur.jwt.spring.JwkSourceMap;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.BadJwtException;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.oauth2.jwt.JwtIssuerValidator;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
+
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ *
+ * Multi-issuer JWT decoder.
+ *
+ */
+
+public class CachedIssuerJwtDecoder implements JwtDecoder {
+
+    private static final String DECODING_ERROR_MESSAGE_TEMPLATE = "An error occurred while attempting to decode the Jwt: %s";
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private List<OAuth2TokenValidator<Jwt>> jwtValidators;
+        private JwkSourceMap jwkSourceMap;
+
+        public Builder withJwkSourceMap(JwkSourceMap jwkSourceMap) {
+            this.jwkSourceMap = jwkSourceMap;
+            return this;
+        }
+
+        public Builder withJwtValidators(List<OAuth2TokenValidator<Jwt>> jwtValidators) {
+            this.jwtValidators = jwtValidators;
+            return this;
+        }
+
+        public CachedIssuerJwtDecoder build() {
+            Map<String, JWKSource> jwkSources = jwkSourceMap.getJwkSources();
+
+            Map<String, JwtDecoder> map = new HashMap<>(jwkSources.size() * 4);
+
+            for (Map.Entry<String, JWKSource> entry : jwkSources.entrySet()) {
+                JWKSource jwkSource = entry.getValue();
+
+                DefaultJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<>();
+                JWSVerificationKeySelector keySelector = new JWSVerificationKeySelector(JWSAlgorithm.Family.SIGNATURE, jwkSource);
+                jwtProcessor.setJWSKeySelector(keySelector);
+
+                NimbusJwtDecoder nimbusJwtDecoder = new NimbusJwtDecoder(jwtProcessor);
+                nimbusJwtDecoder.setJwtValidator(getJwtValidators(entry.getKey()));
+
+                map.put(entry.getKey(), nimbusJwtDecoder);
+            }
+
+            return new CachedIssuerJwtDecoder(map);
+        }
+
+        private DelegatingOAuth2TokenValidator<Jwt> getJwtValidators(String issuer) {
+            List<OAuth2TokenValidator<Jwt>> validators = new ArrayList<>();
+            validators.add(new JwtIssuerValidator(issuer)); // this check is implicit, but lets add it regardless
+            validators.addAll(jwtValidators);
+            DelegatingOAuth2TokenValidator<Jwt> validator = new DelegatingOAuth2TokenValidator<>(validators);
+            return validator;
+        }
+    }
+
+    protected final Map<String, JwtDecoder> decoders;
+
+    public CachedIssuerJwtDecoder(Map<String, JwtDecoder> decoders) {
+        this.decoders = decoders;
+    }
+
+    @Override
+    public Jwt decode(String token) throws JwtException {
+        // note to self: there is two jwt classes, Jwt and JWT
+        try {
+            JWT parse = JWTParser.parse(token);
+
+            JwtDecoder decoder = decoders.get(parse.getJWTClaimsSet().getIssuer());
+            if (decoder != null) {
+                return decoder.decode(token);
+            }
+
+            throw new BadJwtException("Unknown issuer " + parse.getJWTClaimsSet().getIssuer());
+        } catch (ParseException ex) {
+            throw new InvalidBearerTokenException(String.format(DECODING_ERROR_MESSAGE_TEMPLATE, ex.getMessage()), ex);
+        }
+    }
+}

--- a/jwt-server/spring/jwt-spring-grpc-native/src/main/java/org/entur/jwt/spring/grpc/netty/IssuerJwtDecoder.java
+++ b/jwt-server/spring/jwt-spring-grpc-native/src/main/java/org/entur/jwt/spring/grpc/netty/IssuerJwtDecoder.java
@@ -1,27 +1,17 @@
 package org.entur.jwt.spring.grpc.netty;
 
-import com.nimbusds.jose.JWSAlgorithm;
-import com.nimbusds.jose.jwk.source.JWKSource;
-import com.nimbusds.jose.proc.JWSVerificationKeySelector;
-import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTParser;
-import com.nimbusds.jwt.proc.DefaultJWTProcessor;
-import org.entur.jwt.spring.JwkSourceMap;
-import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
-import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.apache.tomcat.util.http.fileupload.IOUtils;
 import org.springframework.security.oauth2.jwt.BadJwtException;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtException;
-import org.springframework.security.oauth2.jwt.JwtIssuerValidator;
-import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.InvalidBearerTokenException;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.text.ParseException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -30,57 +20,12 @@ import java.util.Map;
  *
  */
 
-public class IssuerJwtDecoder implements JwtDecoder {
+public class IssuerJwtDecoder implements JwtDecoder, Closeable {
 
     private static final String DECODING_ERROR_MESSAGE_TEMPLATE = "An error occurred while attempting to decode the Jwt: %s";
 
-    public static Builder newBuilder() {
-        return new Builder();
-    }
-
-    public static class Builder {
-
-        private List<OAuth2TokenValidator<Jwt>> jwtValidators;
-        private JwkSourceMap jwkSourceMap;
-
-        public Builder withJwkSourceMap(JwkSourceMap jwkSourceMap) {
-            this.jwkSourceMap = jwkSourceMap;
-            return this;
-        }
-
-        public Builder withJwtValidators(List<OAuth2TokenValidator<Jwt>> jwtValidators) {
-            this.jwtValidators = jwtValidators;
-            return this;
-        }
-
-        public IssuerJwtDecoder build() {
-            Map<String, JWKSource> jwkSources = jwkSourceMap.getJwkSources();
-
-            Map<String, JwtDecoder> map = new HashMap<>(jwkSources.size() * 4);
-
-            for (Map.Entry<String, JWKSource> entry : jwkSources.entrySet()) {
-                JWKSource jwkSource = entry.getValue();
-
-                DefaultJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<>();
-                JWSVerificationKeySelector keySelector = new JWSVerificationKeySelector(JWSAlgorithm.Family.SIGNATURE, jwkSource);
-                jwtProcessor.setJWSKeySelector(keySelector);
-
-                NimbusJwtDecoder nimbusJwtDecoder = new NimbusJwtDecoder(jwtProcessor);
-                nimbusJwtDecoder.setJwtValidator(getJwtValidators(entry.getKey()));
-
-                map.put(entry.getKey(), nimbusJwtDecoder);
-            }
-
-            return new IssuerJwtDecoder(map);
-        }
-
-        private DelegatingOAuth2TokenValidator<Jwt> getJwtValidators(String issuer) {
-            List<OAuth2TokenValidator<Jwt>> validators = new ArrayList<>();
-            validators.add(new JwtIssuerValidator(issuer)); // this check is implicit, but lets add it regardless
-            validators.addAll(jwtValidators);
-            DelegatingOAuth2TokenValidator<Jwt> validator = new DelegatingOAuth2TokenValidator<>(validators);
-            return validator;
-        }
+    public static JwtDecoderBuilder newBuilder() {
+        return new JwtDecoderBuilder();
     }
 
     protected final Map<String, JwtDecoder> decoders;
@@ -104,5 +49,17 @@ public class IssuerJwtDecoder implements JwtDecoder {
         } catch (ParseException ex) {
             throw new InvalidBearerTokenException(String.format(DECODING_ERROR_MESSAGE_TEMPLATE, ex.getMessage()), ex);
         }
+    }
+
+    @Override
+    public void close() throws IOException {
+        for (Map.Entry<String, JwtDecoder> entry : decoders.entrySet()) {
+            JwtDecoder value = entry.getValue();
+
+            if(value instanceof Closeable c) {
+                IOUtils.closeQuietly(c);
+            }
+        }
+
     }
 }

--- a/jwt-server/spring/jwt-spring-grpc-native/src/main/java/org/entur/jwt/spring/grpc/netty/JwtDecoderBuilder.java
+++ b/jwt-server/spring/jwt-spring-grpc-native/src/main/java/org/entur/jwt/spring/grpc/netty/JwtDecoderBuilder.java
@@ -1,0 +1,161 @@
+package org.entur.jwt.spring.grpc.netty;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.proc.JWSVerificationKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+import org.entur.jwt.spring.JwkSourceMap;
+import org.entur.jwt.spring.actuate.ListEventListener;
+import org.entur.jwt.spring.cache.DecodedJwtCacheJwtDecoder;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtIssuerValidator;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class JwtDecoderBuilder {
+
+    private List<OAuth2TokenValidator<Jwt>> jwtValidators;
+    private Map<String, JWKSource> jwkSources;
+    private Map<String, ListEventListener> jwkEventListeners;
+    private Set<String> decodedJwtCacheIssuers;
+
+    public JwtDecoderBuilder withJwkEventListeners(Map<String, ListEventListener> jwkEventListeners) {
+        this.jwkEventListeners = jwkEventListeners;
+        return this;
+    }
+
+    public JwtDecoderBuilder withJwkSources(Map<String, JWKSource> jwkSources) {
+        this.jwkSources = jwkSources;
+        return this;
+    }
+
+    public JwtDecoderBuilder withDecodedJwtCacheIssuers(Set<String> decodedJwtCacheIssuers) {
+        this.decodedJwtCacheIssuers = decodedJwtCacheIssuers;
+        return this;
+    }
+
+    public JwtDecoderBuilder withJwtValidators(List<OAuth2TokenValidator<Jwt>> jwtValidators) {
+        this.jwtValidators = jwtValidators;
+        return this;
+    }
+
+    public JwtDecoder build() {
+
+        if(decodedJwtCacheIssuers.isEmpty()) {
+            if(jwkSources.size() == 1) {
+                Map.Entry<String, JWKSource> next = jwkSources.entrySet().iterator().next();
+                return createSingleDecoder(next.getKey(), next.getValue());
+            } else {
+                return createMultiDecoder();
+            }
+        } else {
+            if(jwkSources.size() == 1) {
+                Map.Entry<String, JWKSource> next = jwkSources.entrySet().iterator().next();
+                return createSingleCachedDecoder(next.getKey(), next.getValue());
+            } else {
+                return createMultiCachedDecoder();
+            }
+        }
+    }
+
+    private JwtDecoder createMultiCachedDecoder() {
+        Map<String, JwtDecoder> map = new HashMap<>(jwkSources.size() * 4);
+
+        for (Map.Entry<String, JWKSource> entry : jwkSources.entrySet()) {
+            JWKSource jwkSource = entry.getValue();
+            ListEventListener listEventListener = jwkEventListeners.get(entry.getKey());
+
+            DefaultJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<>();
+            JWSVerificationKeySelector keySelector = new JWSVerificationKeySelector(JWSAlgorithm.Family.SIGNATURE, jwkSource);
+            jwtProcessor.setJWSKeySelector(keySelector);
+
+            NimbusJwtDecoder nimbusJwtDecoder = new NimbusJwtDecoder(jwtProcessor);
+            nimbusJwtDecoder.setJwtValidator(getJwtValidators(entry.getKey()));
+
+            JwtDecoder jwtDecoder;
+            if(decodedJwtCacheIssuers.contains(entry.getKey())) {
+                DecodedJwtCacheJwtDecoder decodedJwtCacheJwtDecoder = new DecodedJwtCacheJwtDecoder(nimbusJwtDecoder, getJwtValidators(entry.getKey()), 60_000);
+                listEventListener.addEventListener(decodedJwtCacheJwtDecoder);
+                jwtDecoder = decodedJwtCacheJwtDecoder;
+            } else {
+                jwtDecoder =  nimbusJwtDecoder;
+            }
+
+            map.put(entry.getKey(), jwtDecoder);
+        }
+
+        return new IssuerJwtDecoder(map);
+    }
+
+    public IssuerJwtDecoder createMultiDecoder() {
+        Map<String, JwtDecoder> map = new HashMap<>(jwkSources.size() * 4);
+
+        for (Map.Entry<String, JWKSource> entry : jwkSources.entrySet()) {
+            JWKSource jwkSource = entry.getValue();
+
+
+            DefaultJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<>();
+            JWSVerificationKeySelector keySelector = new JWSVerificationKeySelector(JWSAlgorithm.Family.SIGNATURE, jwkSource);
+            jwtProcessor.setJWSKeySelector(keySelector);
+
+            NimbusJwtDecoder nimbusJwtDecoder = new NimbusJwtDecoder(jwtProcessor);
+
+            // issur check is implicit
+            DelegatingOAuth2TokenValidator<Jwt> validatorsWithoutIssuerCheck = new DelegatingOAuth2TokenValidator<>(jwtValidators);
+            nimbusJwtDecoder.setJwtValidator(validatorsWithoutIssuerCheck);
+
+            map.put(entry.getKey(), nimbusJwtDecoder);
+        }
+
+        return new IssuerJwtDecoder(map);
+    }
+
+    private JwtDecoder createSingleCachedDecoder(String key, JWKSource value) {
+        DefaultJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<>();
+        JWSVerificationKeySelector keySelector = new JWSVerificationKeySelector(JWSAlgorithm.Family.SIGNATURE, value);
+        jwtProcessor.setJWSKeySelector(keySelector);
+
+        NimbusJwtDecoder nimbusJwtDecoder = new NimbusJwtDecoder(jwtProcessor);
+        DelegatingOAuth2TokenValidator<Jwt> validatorsWithIssuerCheck = getJwtValidators(key);
+        nimbusJwtDecoder.setJwtValidator(validatorsWithIssuerCheck);
+
+        if(decodedJwtCacheIssuers.contains(key)) {
+            DelegatingOAuth2TokenValidator<Jwt> validatorsWithoutIssuerCheck = new DelegatingOAuth2TokenValidator<>(jwtValidators);
+            DecodedJwtCacheJwtDecoder decodedJwtCacheJwtDecoder = new DecodedJwtCacheJwtDecoder(nimbusJwtDecoder, validatorsWithoutIssuerCheck, 60_000);
+
+            ListEventListener listEventListener = jwkEventListeners.get(key);
+            listEventListener.addEventListener(decodedJwtCacheJwtDecoder);
+            return decodedJwtCacheJwtDecoder;
+        }
+        return nimbusJwtDecoder;
+    }
+
+    private JwtDecoder createSingleDecoder(String key, JWKSource jwkSource) {
+        DefaultJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<>();
+        JWSVerificationKeySelector keySelector = new JWSVerificationKeySelector(JWSAlgorithm.Family.SIGNATURE, jwkSource);
+        jwtProcessor.setJWSKeySelector(keySelector);
+
+        DelegatingOAuth2TokenValidator<Jwt> validatorsWithIssuerCheck = getJwtValidators(key);
+
+        NimbusJwtDecoder nimbusJwtDecoder = new NimbusJwtDecoder(jwtProcessor);
+        nimbusJwtDecoder.setJwtValidator(validatorsWithIssuerCheck);
+        return nimbusJwtDecoder;
+    }
+
+    private DelegatingOAuth2TokenValidator<Jwt> getJwtValidators(String issuer) {
+        List<OAuth2TokenValidator<Jwt>> validators = new ArrayList<>();
+        validators.add(new JwtIssuerValidator(issuer));
+        validators.addAll(jwtValidators);
+        DelegatingOAuth2TokenValidator<Jwt> validator = new DelegatingOAuth2TokenValidator<>(validators);
+        return validator;
+    }
+}

--- a/jwt-server/spring/jwt-spring-grpc-native/src/main/java/org/entur/jwt/spring/grpc/netty/JwtGrpcAutoConfiguration.java
+++ b/jwt-server/spring/jwt-spring-grpc-native/src/main/java/org/entur/jwt/spring/grpc/netty/JwtGrpcAutoConfiguration.java
@@ -8,12 +8,15 @@ import org.entur.jwt.spring.JwtAuthorityEnricher;
 import org.entur.jwt.spring.JwtAutoConfiguration;
 import org.entur.jwt.spring.KeycloakJwtAuthorityEnricher;
 import org.entur.jwt.spring.NoUserDetailsService;
+import org.entur.jwt.spring.cache.DecodedJwtCacheConfigurationReader;
 import org.entur.jwt.spring.grpc.properties.GrpcPermitAll;
 import org.entur.jwt.spring.grpc.properties.GrpcServicesConfiguration;
 import org.entur.jwt.spring.grpc.properties.ServiceMatcherConfiguration;
 import org.entur.jwt.spring.properties.Auth0Flavour;
 import org.entur.jwt.spring.properties.Flavours;
+import org.entur.jwt.spring.properties.JwtProperties;
 import org.entur.jwt.spring.properties.KeycloakFlavour;
+import org.entur.jwt.spring.properties.SecurityProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -33,6 +36,7 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 
 import java.util.ArrayList;
@@ -41,9 +45,10 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @Configuration
-@EnableConfigurationProperties({GrpcPermitAll.class, Flavours.class})
+@EnableConfigurationProperties({GrpcPermitAll.class, SecurityProperties.class})
 @AutoConfigureAfter(value = {JwtAutoConfiguration.class})
 @AutoConfigureBefore(value = {OAuth2ResourceServerAutoConfiguration.class})
 @ConditionalOnProperty(name = {"entur.jwt.enabled"}, havingValue = "true", matchIfMissing = true)
@@ -55,14 +60,14 @@ public class JwtGrpcAutoConfiguration {
 
     private List<OAuth2TokenValidator<Jwt>> jwtValidators;
 
-    private Flavours flavours;
+    private SecurityProperties securityProperties;
 
     private final Map<String, List<String>> permitAllMappings;
 
-    public JwtGrpcAutoConfiguration(JwkSourceMap jwkSourceMap, List<OAuth2TokenValidator<Jwt>> jwtValidators, GrpcPermitAll permitAll, Flavours flavours) {
+    public JwtGrpcAutoConfiguration(JwkSourceMap jwkSourceMap, List<OAuth2TokenValidator<Jwt>> jwtValidators, GrpcPermitAll permitAll, SecurityProperties securityProperties) {
         this.jwkSourceMap = jwkSourceMap;
         this.jwtValidators = jwtValidators;
-        this.flavours = flavours;
+        this.securityProperties = securityProperties;
 
         if(permitAll.isEnabled()) {
             permitAllMappings = getPermitAllMappings(permitAll.getGrpc());
@@ -114,8 +119,10 @@ public class JwtGrpcAutoConfiguration {
                 requests.allRequests().fullyAuthenticated();
             });
 
-            IssuerJwtDecoder decoder = IssuerJwtDecoder.newBuilder()
-                    .withJwkSourceMap(jwkSourceMap)
+            JwtDecoder decoder = IssuerJwtDecoder.newBuilder()
+                    .withJwkSources(jwkSourceMap.getJwkSources())
+                    .withJwkEventListeners(jwkSourceMap.getJwkEventListeners())
+                    .withDecodedJwtCacheIssuers(DecodedJwtCacheConfigurationReader.convert(securityProperties.getJwt()))
                     .withJwtValidators(jwtValidators)
                     .build();
 
@@ -137,6 +144,7 @@ public class JwtGrpcAutoConfiguration {
     }
 
     private List<JwtAuthorityEnricher> getJwtAuthorityEnrichers(List<JwtAuthorityEnricher> jwtAuthorityEnrichers) {
+        Flavours flavours = securityProperties.getJwt().getFlavours();
         if (flavours.isEnabled()) {
             List<JwtAuthorityEnricher> enrichers = new ArrayList<>(jwtAuthorityEnrichers);
 

--- a/jwt-server/spring/jwt-spring-web/src/main/java/org/entur/jwt/spring/JwtWebSecurityChainAutoConfiguration.java
+++ b/jwt-server/spring/jwt-spring-web/src/main/java/org/entur/jwt/spring/JwtWebSecurityChainAutoConfiguration.java
@@ -12,6 +12,8 @@ import org.entur.jwt.spring.properties.JwtProperties;
 import org.entur.jwt.spring.properties.KeycloakFlavour;
 import org.entur.jwt.spring.properties.MdcProperties;
 import org.entur.jwt.spring.properties.SecurityProperties;
+import org.entur.jwt.spring.properties.jwk.JwkCacheProperties;
+import org.entur.jwt.spring.properties.jwk.JwtTenantProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -36,8 +38,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.AuthorizationFilter;
 import org.springframework.security.web.header.writers.XXssProtectionHeaderWriter;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 import static org.springframework.security.config.http.SessionCreationPolicy.STATELESS;
 
@@ -127,7 +128,6 @@ public class JwtWebSecurityChainAutoConfiguration {
 
             JwtProperties jwt = securityProperties.getJwt();
             if (jwt.isEnabled()) {
-
                 Flavours flavours = jwt.getFlavours();
                 if (flavours.isEnabled()) {
                     List<JwtAuthorityEnricher> enrichers = new ArrayList<>(jwtAuthorityEnrichers);
@@ -145,7 +145,30 @@ public class JwtWebSecurityChainAutoConfiguration {
                     jwtAuthorityEnrichers = enrichers;
                 }
 
-                http.oauth2ResourceServer(new EnturOauth2ResourceServerCustomizer(jwkSourceMap.getJwkSources(), jwtAuthorityEnrichers, jwtValidators));
+                JwkCacheProperties cache = jwt.getJwk().getCache();
+                boolean decodedJwtCache = cache.isEnabled() && cache.getPreemptive().isEnabled() && cache.getPreemptive().getEager().isEnabled();
+
+                Set<String> decodedJwtCacheIssuers;
+                if(decodedJwtCache) {
+                    decodedJwtCacheIssuers = new HashSet<>();
+                    for (Map.Entry<String, JwtTenantProperties> entry : jwt.getTenants().entrySet()) {
+                        JwtTenantProperties value = entry.getValue();
+                        if(value.isEnabled() && value.getDecoderCache().isEnabled()) {
+                            decodedJwtCacheIssuers.add(entry.getKey());
+                        }
+                    }
+                } else {
+                    decodedJwtCacheIssuers = Collections.emptySet();
+                }
+
+                http.oauth2ResourceServer(new EnturOauth2ResourceServerCustomizer(
+                        jwkSourceMap.getJwkSources(),
+                        jwkSourceMap.getJwkEventListeners(),
+                        jwtAuthorityEnrichers,
+                        jwtValidators,
+                        decodedJwtCacheIssuers
+                    )
+                );
             }
 
             MdcProperties mdc = jwt.getMdc();

--- a/jwt-server/spring/jwt-spring-web/src/main/java/org/entur/jwt/spring/JwtWebSecurityChainAutoConfiguration.java
+++ b/jwt-server/spring/jwt-spring-web/src/main/java/org/entur/jwt/spring/JwtWebSecurityChainAutoConfiguration.java
@@ -1,5 +1,6 @@
 package org.entur.jwt.spring;
 
+import org.entur.jwt.spring.cache.DecodedJwtCacheConfigurationReader;
 import org.entur.jwt.spring.config.EnturAuthorizeHttpRequestsCustomizer;
 import org.entur.jwt.spring.config.EnturOauth2ResourceServerCustomizer;
 import org.entur.jwt.spring.config.JwtMappedDiagnosticContextFilter;
@@ -12,8 +13,6 @@ import org.entur.jwt.spring.properties.JwtProperties;
 import org.entur.jwt.spring.properties.KeycloakFlavour;
 import org.entur.jwt.spring.properties.MdcProperties;
 import org.entur.jwt.spring.properties.SecurityProperties;
-import org.entur.jwt.spring.properties.jwk.JwkCacheProperties;
-import org.entur.jwt.spring.properties.jwk.JwtTenantProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -145,28 +144,12 @@ public class JwtWebSecurityChainAutoConfiguration {
                     jwtAuthorityEnrichers = enrichers;
                 }
 
-                JwkCacheProperties cache = jwt.getJwk().getCache();
-                boolean decodedJwtCache = cache.isEnabled() && cache.getPreemptive().isEnabled() && cache.getPreemptive().getEager().isEnabled();
-
-                Set<String> decodedJwtCacheIssuers;
-                if(decodedJwtCache) {
-                    decodedJwtCacheIssuers = new HashSet<>();
-                    for (Map.Entry<String, JwtTenantProperties> entry : jwt.getTenants().entrySet()) {
-                        JwtTenantProperties value = entry.getValue();
-                        if(value.isEnabled() && value.getDecoderCache().isEnabled()) {
-                            decodedJwtCacheIssuers.add(entry.getKey());
-                        }
-                    }
-                } else {
-                    decodedJwtCacheIssuers = Collections.emptySet();
-                }
-
                 http.oauth2ResourceServer(new EnturOauth2ResourceServerCustomizer(
                         jwkSourceMap.getJwkSources(),
                         jwkSourceMap.getJwkEventListeners(),
                         jwtAuthorityEnrichers,
                         jwtValidators,
-                        decodedJwtCacheIssuers
+                        DecodedJwtCacheConfigurationReader.convert(jwt)
                     )
                 );
             }

--- a/jwt-server/spring/jwt-spring-web/src/main/java/org/entur/jwt/spring/config/EnturOauth2ResourceServerCustomizer.java
+++ b/jwt-server/spring/jwt-spring-web/src/main/java/org/entur/jwt/spring/config/EnturOauth2ResourceServerCustomizer.java
@@ -7,6 +7,8 @@ import com.nimbusds.jose.proc.SecurityContext;
 import com.nimbusds.jwt.proc.DefaultJWTProcessor;
 import org.entur.jwt.spring.EnrichedJwtGrantedAuthoritiesConverter;
 import org.entur.jwt.spring.JwtAuthorityEnricher;
+import org.entur.jwt.spring.actuate.ListEventListener;
+import org.entur.jwt.spring.cache.DecodedJwtCacheJwtDecoder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -17,16 +19,14 @@ import org.springframework.security.config.annotation.web.configurers.oauth2.ser
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.jwt.JwtIssuerValidator;
 import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationProvider;
 import org.springframework.security.oauth2.server.resource.authentication.JwtIssuerAuthenticationManagerResolver;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class EnturOauth2ResourceServerCustomizer implements Customizer<OAuth2ResourceServerConfigurer<HttpSecurity>> {
 
@@ -35,11 +35,15 @@ public class EnturOauth2ResourceServerCustomizer implements Customizer<OAuth2Res
     private final Map<String, JWKSource> jwkSources;
     private final List<JwtAuthorityEnricher> jwtAuthorityEnrichers;
     private final List<OAuth2TokenValidator<Jwt>> jwtValidators;
+    private final Map<String, ListEventListener> jwkEventListeners;
+    private final Set<String> decodedJwtCacheIssuers;
 
-    public EnturOauth2ResourceServerCustomizer(Map<String, JWKSource> jwkSources, List<JwtAuthorityEnricher> jwtAuthorityEnrichers, List<OAuth2TokenValidator<Jwt>> jwtValidators) {
+    public EnturOauth2ResourceServerCustomizer(Map<String, JWKSource> jwkSources, Map<String, ListEventListener> jwkEventListeners, List<JwtAuthorityEnricher> jwtAuthorityEnrichers, List<OAuth2TokenValidator<Jwt>> jwtValidators, Set<String> decodedJwtCacheIssuers) {
         this.jwkSources = jwkSources;
+        this.jwkEventListeners = jwkEventListeners;
         this.jwtAuthorityEnrichers = jwtAuthorityEnrichers;
         this.jwtValidators = jwtValidators;
+        this.decodedJwtCacheIssuers = decodedJwtCacheIssuers;
     }
 
     @Override
@@ -47,22 +51,38 @@ public class EnturOauth2ResourceServerCustomizer implements Customizer<OAuth2Res
 
         if(LOGGER.isDebugEnabled()) LOGGER.debug("Customize {} issuers", jwkSources.size());
 
+        if(!decodedJwtCacheIssuers.isEmpty()) {
+            if(LOGGER.isDebugEnabled()) LOGGER.debug("Cache decoded JWTs for issuers {}", decodedJwtCacheIssuers);
+        }
+
         Map<String, AuthenticationManager> map = new HashMap<>(); // thread safe for reading
 
         for (Map.Entry<String, JWKSource> entry : jwkSources.entrySet()) {
             JWKSource jwkSource = entry.getValue();
+            ListEventListener listEventListener = jwkEventListeners.get(entry.getKey());
 
             DefaultJWTProcessor<SecurityContext> jwtProcessor = new DefaultJWTProcessor<>();
             JWSVerificationKeySelector keySelector = new JWSVerificationKeySelector(JWSAlgorithm.Family.SIGNATURE, jwkSource);
             jwtProcessor.setJWSKeySelector(keySelector);
 
             NimbusJwtDecoder nimbusJwtDecoder = new NimbusJwtDecoder(jwtProcessor);
-            nimbusJwtDecoder.setJwtValidator(getJwtValidators(entry.getKey()));
+            DelegatingOAuth2TokenValidator<Jwt> jwtValidators = getJwtValidators(entry.getKey());
+
+            nimbusJwtDecoder.setJwtValidator(jwtValidators);
+
+            JwtDecoder jwtDecoder;
+            if(decodedJwtCacheIssuers.contains(entry.getKey())) {
+                DecodedJwtCacheJwtDecoder decodedJwtCacheJwtDecoder = new DecodedJwtCacheJwtDecoder(nimbusJwtDecoder, jwtValidators);
+                listEventListener.addEventListener(decodedJwtCacheJwtDecoder);
+                jwtDecoder = decodedJwtCacheJwtDecoder;
+            } else {
+                jwtDecoder =  nimbusJwtDecoder;
+            }
 
             JwtAuthenticationConverter jwtAuthenticationConverter = new JwtAuthenticationConverter();
             jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(new EnrichedJwtGrantedAuthoritiesConverter(jwtAuthorityEnrichers));
 
-            JwtAuthenticationProvider authenticationProvider = new JwtAuthenticationProvider(nimbusJwtDecoder);
+            JwtAuthenticationProvider authenticationProvider = new JwtAuthenticationProvider(jwtDecoder);
             authenticationProvider.setJwtAuthenticationConverter(jwtAuthenticationConverter);
 
             map.put(entry.getKey(), authenticationProvider::authenticate);

--- a/jwt-server/spring/jwt-spring-web/src/main/java/org/entur/jwt/spring/config/EnturOauth2ResourceServerCustomizer.java
+++ b/jwt-server/spring/jwt-spring-web/src/main/java/org/entur/jwt/spring/config/EnturOauth2ResourceServerCustomizer.java
@@ -72,7 +72,7 @@ public class EnturOauth2ResourceServerCustomizer implements Customizer<OAuth2Res
 
             JwtDecoder jwtDecoder;
             if(decodedJwtCacheIssuers.contains(entry.getKey())) {
-                DecodedJwtCacheJwtDecoder decodedJwtCacheJwtDecoder = new DecodedJwtCacheJwtDecoder(nimbusJwtDecoder, jwtValidators);
+                DecodedJwtCacheJwtDecoder decodedJwtCacheJwtDecoder = new DecodedJwtCacheJwtDecoder(nimbusJwtDecoder, jwtValidators, 60_000);
                 listEventListener.addEventListener(decodedJwtCacheJwtDecoder);
                 jwtDecoder = decodedJwtCacheJwtDecoder;
             } else {


### PR DESCRIPTION
Cache JWTs for selected issuers, when relatively few clients. 

This improves the authenticate performance by a lot. System performance improvement should be somewhere in the 1-2% range. 

 * Must be explicitly enabled per issuer.
   * Also requires eager background refresh, so that JWKs are revisited at an acceptable frequency
     * trigger below refresh within reasonable time
 * When JWKs are refreshed, kick out JWTs using keys no longer available
   * on a background thread.
 * Do claim validation checks also for cached JWTs (remove from cache if fails).

TODO global vs per issuer when multiple issuers.