### PR TITLE
Simplify AuthenticationProvider handling for single JWT issuer

### DIFF
--- a/jwt-server/spring/jwt-spring-grpc-native/src/main/java/org/entur/jwt/spring/grpc/netty/IssuerJwtDecoder.java
+++ b/jwt-server/spring/jwt-spring-grpc-native/src/main/java/org/entur/jwt/spring/grpc/netty/IssuerJwtDecoder.java
@@ -53,7 +53,7 @@ public class IssuerJwtDecoder implements JwtDecoder {
             return this;
         }
 
-        public IssuerJwtDecoder build() {
+        public JwtDecoder build() {
             Map<String, JWKSource> jwkSources = jwkSourceMap.getJwkSources();
 
             Map<String, JwtDecoder> map = new HashMap<>(jwkSources.size() * 4);
@@ -71,12 +71,16 @@ public class IssuerJwtDecoder implements JwtDecoder {
                 map.put(entry.getKey(), nimbusJwtDecoder);
             }
 
+            if(map.size() == 1) {
+                return map.values().iterator().next();
+            }
+
             return new IssuerJwtDecoder(map);
         }
 
         private DelegatingOAuth2TokenValidator<Jwt> getJwtValidators(String issuer) {
             List<OAuth2TokenValidator<Jwt>> validators = new ArrayList<>();
-            validators.add(new JwtIssuerValidator(issuer)); // this check is implicit, but lets add it regardless
+            validators.add(new JwtIssuerValidator(issuer));
             validators.addAll(jwtValidators);
             DelegatingOAuth2TokenValidator<Jwt> validator = new DelegatingOAuth2TokenValidator<>(validators);
             return validator;

--- a/jwt-server/spring/jwt-spring-grpc-native/src/main/java/org/entur/jwt/spring/grpc/netty/JwtGrpcAutoConfiguration.java
+++ b/jwt-server/spring/jwt-spring-grpc-native/src/main/java/org/entur/jwt/spring/grpc/netty/JwtGrpcAutoConfiguration.java
@@ -33,6 +33,7 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
 
 import java.util.ArrayList;
@@ -114,7 +115,7 @@ public class JwtGrpcAutoConfiguration {
                 requests.allRequests().fullyAuthenticated();
             });
 
-            IssuerJwtDecoder decoder = IssuerJwtDecoder.newBuilder()
+            JwtDecoder decoder = IssuerJwtDecoder.newBuilder()
                     .withJwkSourceMap(jwkSourceMap)
                     .withJwtValidators(jwtValidators)
                     .build();

--- a/jwt-server/spring/jwt-spring-web/src/main/java/org/entur/jwt/spring/config/EnturOauth2ResourceServerCustomizer.java
+++ b/jwt-server/spring/jwt-spring-web/src/main/java/org/entur/jwt/spring/config/EnturOauth2ResourceServerCustomizer.java
@@ -68,16 +68,21 @@ public class EnturOauth2ResourceServerCustomizer implements Customizer<OAuth2Res
             map.put(entry.getKey(), authenticationProvider::authenticate);
         }
 
-        AuthenticationManagerResolver<String> issuer = new IssuerAuthenticationManagerResolver(map);
+        if(map.size() == 1) {
+            AuthenticationManager next = map.values().iterator().next();
+            configurer.authenticationManagerResolver(issuer -> next);
+        } else {
+            AuthenticationManagerResolver<String> issuer = new IssuerAuthenticationManagerResolver(map);
 
-        JwtIssuerAuthenticationManagerResolver jwtIssuerAuthenticationManagerResolver = new JwtIssuerAuthenticationManagerResolver(issuer);
+            JwtIssuerAuthenticationManagerResolver jwtIssuerAuthenticationManagerResolver = new JwtIssuerAuthenticationManagerResolver(issuer);
 
-        configurer.authenticationManagerResolver(jwtIssuerAuthenticationManagerResolver);
+            configurer.authenticationManagerResolver(jwtIssuerAuthenticationManagerResolver);
+        }
     }
 
     private DelegatingOAuth2TokenValidator<Jwt> getJwtValidators(String issuer) {
         List<OAuth2TokenValidator<Jwt>> validators = new ArrayList<>();
-        validators.add(new JwtIssuerValidator(issuer)); // this check is implicit, but lets add it regardless
+        validators.add(new JwtIssuerValidator(issuer));
         validators.addAll(jwtValidators);
         DelegatingOAuth2TokenValidator<Jwt> validator = new DelegatingOAuth2TokenValidator<>(validators);
         return validator;

--- a/jwt-server/spring/jwt-spring-web/src/main/java/org/entur/jwt/spring/config/EnturOauth2ResourceServerCustomizer.java
+++ b/jwt-server/spring/jwt-spring-web/src/main/java/org/entur/jwt/spring/config/EnturOauth2ResourceServerCustomizer.java
@@ -70,7 +70,7 @@ public class EnturOauth2ResourceServerCustomizer implements Customizer<OAuth2Res
 
         if(map.size() == 1) {
             AuthenticationManager next = map.values().iterator().next();
-            configurer.authenticationManagerResolver(issuer -> next);
+            configurer.authenticationManagerResolver(request -> next);
         } else {
             AuthenticationManagerResolver<String> issuer = new IssuerAuthenticationManagerResolver(map);
 

--- a/jwt-server/spring/jwt-spring-webflux/src/main/java/org/entur/jwt/spring/config/EnturOauth2ResourceServerCustomizer.java
+++ b/jwt-server/spring/jwt-spring-webflux/src/main/java/org/entur/jwt/spring/config/EnturOauth2ResourceServerCustomizer.java
@@ -29,6 +29,7 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import org.springframework.security.oauth2.server.resource.authentication.JwtIssuerReactiveAuthenticationManagerResolver;
 import org.springframework.security.oauth2.server.resource.authentication.JwtReactiveAuthenticationManager;
 import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtAuthenticationConverterAdapter;
+import reactor.core.publisher.Mono;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -82,11 +83,16 @@ public class EnturOauth2ResourceServerCustomizer implements Customizer<ServerHtt
             map.put(entry.getKey(), jwtReactiveAuthenticationManager);
         }
 
-        IssuerAuthenticationManagerResolver issuer = new IssuerAuthenticationManagerResolver(map);
+        if(map.size() == 1) {
+            ReactiveAuthenticationManager next = map.values().iterator().next();
+            configurer.authenticationManagerResolver(request -> Mono.just(next));
+        } else {
+            IssuerAuthenticationManagerResolver issuer = new IssuerAuthenticationManagerResolver(map);
 
-        JwtIssuerReactiveAuthenticationManagerResolver jwtIssuerAuthenticationManagerResolver = new JwtIssuerReactiveAuthenticationManagerResolver(issuer);
+            JwtIssuerReactiveAuthenticationManagerResolver jwtIssuerAuthenticationManagerResolver = new JwtIssuerReactiveAuthenticationManagerResolver(issuer);
 
-        configurer.authenticationManagerResolver(jwtIssuerAuthenticationManagerResolver);
+            configurer.authenticationManagerResolver(jwtIssuerAuthenticationManagerResolver);
+        }
     }
 
     private static <C extends SecurityContext> JWTClaimsSet createClaimsSet(JWTProcessor<C> jwtProcessor,

--- a/jwt-server/spring/jwt-spring-webflux/src/main/java/org/entur/jwt/spring/config/EnturOauth2ResourceServerCustomizer.java
+++ b/jwt-server/spring/jwt-spring-webflux/src/main/java/org/entur/jwt/spring/config/EnturOauth2ResourceServerCustomizer.java
@@ -85,7 +85,8 @@ public class EnturOauth2ResourceServerCustomizer implements Customizer<ServerHtt
 
         if(map.size() == 1) {
             ReactiveAuthenticationManager next = map.values().iterator().next();
-            configurer.authenticationManagerResolver(request -> Mono.just(next));
+            Mono<ReactiveAuthenticationManager> authenticationManager = Mono.just(next);
+            configurer.authenticationManagerResolver(request -> authenticationManager);
         } else {
             IssuerAuthenticationManagerResolver issuer = new IssuerAuthenticationManagerResolver(map);
 

--- a/jwt-server/spring/jwt-spring-webflux/src/main/java/org/entur/jwt/spring/config/EnturOauth2ResourceServerCustomizer.java
+++ b/jwt-server/spring/jwt-spring-webflux/src/main/java/org/entur/jwt/spring/config/EnturOauth2ResourceServerCustomizer.java
@@ -109,7 +109,7 @@ public class EnturOauth2ResourceServerCustomizer implements Customizer<ServerHtt
 
     private DelegatingOAuth2TokenValidator<Jwt> getJwtValidators(Map.Entry<String, JWKSource> entry) {
         List<OAuth2TokenValidator<Jwt>> validators = new ArrayList<>();
-        validators.add(new JwtIssuerValidator(entry.getKey())); // this check is implicit, but lets add it regardless
+        validators.add(new JwtIssuerValidator(entry.getKey()));
         validators.addAll(jwtValidators);
         DelegatingOAuth2TokenValidator<Jwt> validator = new DelegatingOAuth2TokenValidator<>(validators);
         return validator;


### PR DESCRIPTION
Enforce issuer via JWT claim-validator instead of `JwtIssuerAuthenticationManagerResolver` internal map lookup; avoiding `JWTParser.parse(..)` with `SignedJWT.getJWTClaimSet()` just to get the issuer from the JWT.

Internal benchmarks seem to indicate about 18% better performance in the authenticate step -> 0.35 % system:

<img width="1344" height="206" alt="image" src="https://github.com/user-attachments/assets/68bb2799-6c85-4755-94d0-ae11c359964f" />

=>

<img width="1344" height="206" alt="image" src="https://github.com/user-attachments/assets/c44ef83b-7c2f-4597-b9fa-89003876033f" />

