### PR TITLE
grpc: Fix typo in configuration property binding

### DIFF
--- a/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/properties/Flavours.java
+++ b/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/properties/Flavours.java
@@ -1,8 +1,5 @@
 package org.entur.jwt.spring.properties;
 
-import org.springframework.boot.context.properties.ConfigurationProperties;
-
-@ConfigurationProperties(prefix = "entur.jwt.flavour")
 public class Flavours {
 
     private boolean enabled = true;
@@ -26,7 +23,6 @@ public class Flavours {
     public void setKeycloak(KeycloakFlavour keycloak) {
         this.keycloak = keycloak;
     }
-
 
     public void setEnabled(boolean enabled) {
         this.enabled = enabled;

--- a/jwt-server/spring/jwt-spring-grpc-native/src/main/java/org/entur/jwt/spring/grpc/netty/JwtGrpcAutoConfiguration.java
+++ b/jwt-server/spring/jwt-spring-grpc-native/src/main/java/org/entur/jwt/spring/grpc/netty/JwtGrpcAutoConfiguration.java
@@ -13,7 +13,9 @@ import org.entur.jwt.spring.grpc.properties.GrpcServicesConfiguration;
 import org.entur.jwt.spring.grpc.properties.ServiceMatcherConfiguration;
 import org.entur.jwt.spring.properties.Auth0Flavour;
 import org.entur.jwt.spring.properties.Flavours;
+import org.entur.jwt.spring.properties.JwtProperties;
 import org.entur.jwt.spring.properties.KeycloakFlavour;
+import org.entur.jwt.spring.properties.SecurityProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -44,7 +46,7 @@ import java.util.List;
 import java.util.Map;
 
 @Configuration
-@EnableConfigurationProperties({GrpcPermitAll.class, Flavours.class})
+@EnableConfigurationProperties({GrpcPermitAll.class, SecurityProperties.class})
 @AutoConfigureAfter(value = {JwtAutoConfiguration.class})
 @AutoConfigureBefore(value = {OAuth2ResourceServerAutoConfiguration.class})
 @ConditionalOnProperty(name = {"entur.jwt.enabled"}, havingValue = "true", matchIfMissing = true)
@@ -56,14 +58,14 @@ public class JwtGrpcAutoConfiguration {
 
     private List<OAuth2TokenValidator<Jwt>> jwtValidators;
 
-    private Flavours flavours;
+    private SecurityProperties securityProperties;
 
     private final Map<String, List<String>> permitAllMappings;
 
-    public JwtGrpcAutoConfiguration(JwkSourceMap jwkSourceMap, List<OAuth2TokenValidator<Jwt>> jwtValidators, GrpcPermitAll permitAll, Flavours flavours) {
+    public JwtGrpcAutoConfiguration(JwkSourceMap jwkSourceMap, List<OAuth2TokenValidator<Jwt>> jwtValidators, GrpcPermitAll permitAll, SecurityProperties securityProperties) {
         this.jwkSourceMap = jwkSourceMap;
         this.jwtValidators = jwtValidators;
-        this.flavours = flavours;
+        this.securityProperties = securityProperties;
 
         if(permitAll.isEnabled()) {
             permitAllMappings = getPermitAllMappings(permitAll.getGrpc());
@@ -138,6 +140,8 @@ public class JwtGrpcAutoConfiguration {
     }
 
     private List<JwtAuthorityEnricher> getJwtAuthorityEnrichers(List<JwtAuthorityEnricher> jwtAuthorityEnrichers) {
+        JwtProperties jwtProperties = securityProperties.getJwt();
+        Flavours flavours = jwtProperties.getFlavours();
         if (flavours.isEnabled()) {
             List<JwtAuthorityEnricher> enrichers = new ArrayList<>(jwtAuthorityEnrichers);
 


### PR DESCRIPTION
Rather get the root properties and drill down from there. gRPC only.

The setting is pretty obscure, default values make the most sense. 

Potentially breaking change, but not in any of our own apps.