### PR TITLE
Adjust workflows for dual legacy branch publishing (5x and 6x)

### DIFF
--- a/.github/workflows/deploy-5x-legacy-branch-manual.yml
+++ b/.github/workflows/deploy-5x-legacy-branch-manual.yml
@@ -1,4 +1,4 @@
-name: Deploy legacy branch to Maven Central
+name: Deploy 5.x legacy branch to Maven Central
 on:
   workflow_dispatch:
     inputs:
@@ -12,6 +12,7 @@ on:
 
 jobs:
   deploy-maven:
+    if: github.ref_name == '5.x'
     uses: entur/gha-maven-central/.github/workflows/maven-publish.yml@main
     secrets: inherit
     permissions:
@@ -20,7 +21,7 @@ jobs:
     with:
       next_version: ${{ inputs.version-increment }}
       version_strategy: tag
-      version_tag_prefix: legacy-v
+      version_tag_prefix: 5x-legacy-v
       java_version: 25
 
   post-failure-to-slack:

--- a/.github/workflows/deploy-6x-legacy-branch-manual.yml
+++ b/.github/workflows/deploy-6x-legacy-branch-manual.yml
@@ -1,0 +1,49 @@
+name: Deploy 6.x legacy branch to Maven Central
+on:
+  workflow_dispatch:
+    inputs:
+      version-increment:
+        description: 'Version-increment'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+
+jobs:
+  deploy-maven:
+    if: github.ref_name == '6.x'
+    uses: entur/gha-maven-central/.github/workflows/maven-publish.yml@main
+    secrets: inherit
+    permissions:
+      contents: write
+      issues: write
+    with:
+      next_version: ${{ inputs.version-increment }}
+      version_strategy: tag
+      version_tag_prefix: 6x-legacy-v
+      java_version: 25
+
+  post-failure-to-slack:
+    needs: deploy-maven
+    if: failure()
+    uses: entur/gha-slack/.github/workflows/post.yml@v3
+    permissions:
+      contents: read
+    with:
+      channel_id: ${{ vars.CHANNEL_ID }}
+      message: "🔴 Maven artifact deploy failed for ${{ github.repository }}\n ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+    secrets: inherit
+
+  post-success-to-slack:
+    needs: deploy-maven
+    if: success()
+    uses: entur/gha-slack/.github/workflows/post.yml@v3
+    permissions:
+      contents: read
+    with:
+      channel_id: ${{ vars.CHANNEL_ID}}
+      message: "🟢 Maven artifact deploy success for ${{ github.repository }}\n ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+    secrets: inherit
+
+


### PR DESCRIPTION
Branches:
 * 5.x for Spring Boot 3.5
 * [6.x](https://github.com/entur/jwt-resource-server/tree/6.x) for Spring Boot 4.0.x from 6.1.6
 * main on [Spring Boot 4.1.x](https://github.com/entur/jwt-resource-server/pull/312)

Updates
 * explicit workflows with branch check condition
 * new tag pattern to differentiate between legacy versions

Checklist
 * clone previous latest tag with new legacy prefix
   * https://github.com/entur/jwt-resource-server/releases/tag/5x-legacy-v5.2.8
   * https://github.com/entur/jwt-resource-server/releases/tag/6x-legacy-v6.0.5