### PR TITLE
Move configuration of optional bean to avoid ordering problem

### DIFF
--- a/jwt-server/spring/jwt-spring-web/src/main/java/org/entur/jwt/spring/JwtWebSecurityChainAutoConfiguration.java
+++ b/jwt-server/spring/jwt-spring-web/src/main/java/org/entur/jwt/spring/JwtWebSecurityChainAutoConfiguration.java
@@ -89,21 +89,6 @@ public class JwtWebSecurityChainAutoConfiguration {
         return new NoUserDetailsService();  // avoid the default user.
     }
 
-    @Bean
-    @ConditionalOnProperty(name = "entur.jwt.decode.header.map-to-issuer.enabled", havingValue = "true")
-    @ConditionalOnMissingBean(JwtHeaderToIssuerMapper.class)
-    public JwtHeaderToIssuerMapper jwtHeaderToIssuerMapper(SecurityProperties securityProperties) {
-        int maxSize = securityProperties.getJwt().getDecode().getHeader().getMapToIssuer().getMaxSize();
-        return maxSize != -1 ? new BoundedJwtHeaderToIssuerMapper(maxSize) : new JwtHeaderToIssuerMapper();
-    }
-
-    @Bean
-    @ConditionalOnProperty(name = "entur.jwt.decode.header.map-to-issuer.enabled", havingValue = "true")
-    @ConditionalOnMissingBean(JwtHeaderToIssuerMapperDecider.class)
-    public JwtHeaderToIssuerMapperDecider jwtHeaderToIssuerHeaderMapperDecider() {
-        return new DefaultJwtHeaderToIssuerMapperDecider();
-    }
-
     @Configuration
     @ConditionalOnMissingBean(name = BeanIds.SPRING_SECURITY_FILTER_CHAIN)
     @ConditionalOnExpression("${entur.authorization.enabled:true} || ${entur.jwt.enabled:true}")
@@ -112,14 +97,23 @@ public class JwtWebSecurityChainAutoConfiguration {
 
         private SecurityProperties securityProperties;
 
-        @Autowired(required = false)
-        private JwtHeaderToIssuerMapper jwtHeaderToIssuerMapper;
-
-        @Autowired(required = false)
-        private JwtHeaderToIssuerMapperDecider jwtHeaderToIssuerMapperDecider;
-
         public CompositeWebSecurityConfigurerAdapter(SecurityProperties securityProperties) {
             this.securityProperties = securityProperties;
+        }
+
+        @Bean
+        @ConditionalOnProperty(name = "entur.jwt.decode.header.map-to-issuer.enabled", havingValue = "true")
+        @ConditionalOnMissingBean(JwtHeaderToIssuerMapper.class)
+        public JwtHeaderToIssuerMapper jwtHeaderToIssuerMapper(SecurityProperties securityProperties) {
+            int maxSize = securityProperties.getJwt().getDecode().getHeader().getMapToIssuer().getMaxSize();
+            return maxSize != -1 ? new BoundedJwtHeaderToIssuerMapper(maxSize) : new JwtHeaderToIssuerMapper();
+        }
+
+        @Bean
+        @ConditionalOnProperty(name = "entur.jwt.decode.header.map-to-issuer.enabled", havingValue = "true")
+        @ConditionalOnMissingBean(JwtHeaderToIssuerMapperDecider.class)
+        public JwtHeaderToIssuerMapperDecider jwtHeaderToIssuerHeaderMapperDecider() {
+            return new DefaultJwtHeaderToIssuerMapperDecider();
         }
 
         @Bean
@@ -143,7 +137,9 @@ public class JwtWebSecurityChainAutoConfiguration {
                 HttpSecurity http,
                 JwkSourceMap jwkSourceMap,
                 List<JwtAuthorityEnricher> jwtAuthorityEnrichers,
-                List<OAuth2TokenValidator<Jwt>> jwtValidators
+                List<OAuth2TokenValidator<Jwt>> jwtValidators,
+                @Autowired(required = false) JwtHeaderToIssuerMapper jwtHeaderToIssuerMapper,
+                @Autowired(required = false) JwtHeaderToIssuerMapperDecider jwtHeaderToIssuerMapperDecider
         ) throws Exception {
 
             AuthorizationProperties authorization = securityProperties.getAuthorization();


### PR DESCRIPTION
Error from abt-core in dev startup:

```
Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'shutdownService': Unsatisfied dependency expressed through field 'grpcServerLifecycle': Error creating bean with name 'shadedNettyGrpcServerLifecycle' defined in class path resource [org/springframework/boot/grpc/server/autoconfigure/ShadedNettyGrpcServerConfiguration.class]: Unsatisfied dependency expressed through method 'shadedNettyGrpcServerLifecycle' parameter 0: Error creating bean with name 'shadedNettyGrpcServerFactory' defined in class path resource [org/springframework/boot/grpc/server/autoconfigure/ShadedNettyGrpcServerConfiguration.class]: Unsatisfied dependency expressed through method 'shadedNettyGrpcServerFactory' parameter 2: Error creating bean with name 'grpcServiceConfigurer' defined in class path resource [org/springframework/boot/grpc/server/autoconfigure/GrpcServerAutoConfiguration.class]: Error creating bean with name 'jwtSecurityFilterChain' defined in class path resource [org/entur/jwt/spring/grpc/netty/JwtGrpcAutoConfiguration.class]: Failed to instantiate [org.springframework.grpc.server.security.AuthenticationProcessInterceptor]: Factory method 'jwtSecurityFilterChain' threw exception with message: java.lang.IllegalStateException: JwtHeaderToIssuerMapper bean is required when 'entur.jwt.decode.header.map-to-issuer.enabled=true' but was not found in the application context
```

so seemingly a nested configuration does not wait for a optional bean in its parent configuration. 

This changes ensures only a single configuration is involved (and thus a single order) for the above. Also maybe a more correct placement for the bean config.