### PR TITLE
Reduce duplicated config to single; move to common AutoConfiguration

### DIFF
--- a/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/JwtAutoConfiguration.java
+++ b/jwt-server/spring/jwt-spring-common/src/main/java/org/entur/jwt/spring/JwtAutoConfiguration.java
@@ -1,6 +1,10 @@
 package org.entur.jwt.spring;
 
 import org.entur.jwt.spring.actuate.ListJwksHealthIndicator;
+import org.entur.jwt.spring.decode.BoundedJwtHeaderToIssuerMapper;
+import org.entur.jwt.spring.decode.DefaultJwtHeaderToIssuerMapperDecider;
+import org.entur.jwt.spring.decode.JwtHeaderToIssuerMapperDecider;
+import org.entur.jwt.spring.decode.JwtHeaderToIssuerMapper;
 import org.entur.jwt.spring.properties.JwtProperties;
 import org.entur.jwt.spring.properties.SecurityProperties;
 import org.entur.jwt.spring.properties.jwk.JwtTenantProperties;
@@ -67,6 +71,19 @@ public class JwtAutoConfiguration {
         return oAuth2TokenValidatorFactory.create(properties.getJwt().getClaims());
     }
 
+    @Bean
+    @ConditionalOnProperty(name = "entur.jwt.decode.header.map-to-issuer.enabled", havingValue = "true")
+    @ConditionalOnMissingBean(JwtHeaderToIssuerMapper.class)
+    public JwtHeaderToIssuerMapper jwtHeaderToIssuerMapper(SecurityProperties securityProperties) {
+        int maxSize = securityProperties.getJwt().getDecode().getHeader().getMapToIssuer().getMaxSize();
+        return maxSize != -1 ? new BoundedJwtHeaderToIssuerMapper(maxSize) : new JwtHeaderToIssuerMapper();
+    }
 
+    @Bean
+    @ConditionalOnProperty(name = "entur.jwt.decode.header.map-to-issuer.enabled", havingValue = "true")
+    @ConditionalOnMissingBean(JwtHeaderToIssuerMapperDecider.class)
+    public JwtHeaderToIssuerMapperDecider jwtHeaderToIssuerMapperDecider() {
+        return new DefaultJwtHeaderToIssuerMapperDecider();
+    }
 
 }

--- a/jwt-server/spring/jwt-spring-grpc-native/src/main/java/org/entur/jwt/spring/grpc/netty/JwtGrpcAutoConfiguration.java
+++ b/jwt-server/spring/jwt-spring-grpc-native/src/main/java/org/entur/jwt/spring/grpc/netty/JwtGrpcAutoConfiguration.java
@@ -8,8 +8,6 @@ import org.entur.jwt.spring.JwtAuthorityEnricher;
 import org.entur.jwt.spring.JwtAutoConfiguration;
 import org.entur.jwt.spring.KeycloakJwtAuthorityEnricher;
 import org.entur.jwt.spring.NoUserDetailsService;
-import org.entur.jwt.spring.decode.BoundedJwtHeaderToIssuerMapper;
-import org.entur.jwt.spring.decode.DefaultJwtHeaderToIssuerMapperDecider;
 import org.entur.jwt.spring.decode.JwtHeaderToIssuerMapperDecider;
 import org.entur.jwt.spring.decode.JwtHeaderToIssuerMapper;
 import org.entur.jwt.spring.grpc.properties.GrpcPermitAll;
@@ -98,21 +96,6 @@ public class JwtGrpcAutoConfiguration {
     @ConditionalOnMissingBean(JwtAuthorityEnricher.class)
     public JwtAuthorityEnricher jwtAuthorityEnricher() {
         return new DefaultJwtAuthorityEnricher();
-    }
-
-    @Bean
-    @ConditionalOnProperty(name = "entur.jwt.decode.header.map-to-issuer.enabled", havingValue = "true")
-    @ConditionalOnMissingBean(JwtHeaderToIssuerMapper.class)
-    public JwtHeaderToIssuerMapper jwtHeaderToIssuerMapper() {
-        int maxSize = securityProperties.getJwt().getDecode().getHeader().getMapToIssuer().getMaxSize();
-        return maxSize != -1 ? new BoundedJwtHeaderToIssuerMapper(maxSize) : new JwtHeaderToIssuerMapper();
-    }
-
-    @Bean
-    @ConditionalOnProperty(name = "entur.jwt.decode.header.map-to-issuer.enabled", havingValue = "true")
-    @ConditionalOnMissingBean(JwtHeaderToIssuerMapperDecider.class)
-    public JwtHeaderToIssuerMapperDecider jwtHeaderToIssuerMapperDecider() {
-        return new DefaultJwtHeaderToIssuerMapperDecider();
     }
 
     @Bean

--- a/jwt-server/spring/jwt-spring-web/src/main/java/org/entur/jwt/spring/JwtWebSecurityChainAutoConfiguration.java
+++ b/jwt-server/spring/jwt-spring-web/src/main/java/org/entur/jwt/spring/JwtWebSecurityChainAutoConfiguration.java
@@ -3,8 +3,6 @@ package org.entur.jwt.spring;
 import org.entur.jwt.spring.config.EnturAuthorizeHttpRequestsCustomizer;
 import org.entur.jwt.spring.config.EnturOauth2ResourceServerCustomizer;
 import org.entur.jwt.spring.config.JwtMappedDiagnosticContextFilter;
-import org.entur.jwt.spring.decode.BoundedJwtHeaderToIssuerMapper;
-import org.entur.jwt.spring.decode.DefaultJwtHeaderToIssuerMapperDecider;
 import org.entur.jwt.spring.decode.JwtHeaderToIssuerMapperDecider;
 import org.entur.jwt.spring.decode.JwtHeaderToIssuerMapper;
 import org.entur.jwt.spring.filter.log.JwtMappedDiagnosticContextMapper;
@@ -99,21 +97,6 @@ public class JwtWebSecurityChainAutoConfiguration {
 
         public CompositeWebSecurityConfigurerAdapter(SecurityProperties securityProperties) {
             this.securityProperties = securityProperties;
-        }
-
-        @Bean
-        @ConditionalOnProperty(name = "entur.jwt.decode.header.map-to-issuer.enabled", havingValue = "true")
-        @ConditionalOnMissingBean(JwtHeaderToIssuerMapper.class)
-        public JwtHeaderToIssuerMapper jwtHeaderToIssuerMapper(SecurityProperties securityProperties) {
-            int maxSize = securityProperties.getJwt().getDecode().getHeader().getMapToIssuer().getMaxSize();
-            return maxSize != -1 ? new BoundedJwtHeaderToIssuerMapper(maxSize) : new JwtHeaderToIssuerMapper();
-        }
-
-        @Bean
-        @ConditionalOnProperty(name = "entur.jwt.decode.header.map-to-issuer.enabled", havingValue = "true")
-        @ConditionalOnMissingBean(JwtHeaderToIssuerMapperDecider.class)
-        public JwtHeaderToIssuerMapperDecider jwtHeaderToIssuerHeaderMapperDecider() {
-            return new DefaultJwtHeaderToIssuerMapperDecider();
         }
 
         @Bean

--- a/jwt-server/spring/jwt-spring-webflux/src/main/java/org/entur/jwt/spring/JwtWebFluxSecurityAutoConfiguration.java
+++ b/jwt-server/spring/jwt-spring-webflux/src/main/java/org/entur/jwt/spring/JwtWebFluxSecurityAutoConfiguration.java
@@ -2,8 +2,6 @@ package org.entur.jwt.spring;
 
 import org.entur.jwt.spring.config.EnturAuthorizeHttpRequestsCustomizer;
 import org.entur.jwt.spring.config.EnturOauth2ResourceServerCustomizer;
-import org.entur.jwt.spring.decode.BoundedJwtHeaderToIssuerMapper;
-import org.entur.jwt.spring.decode.DefaultJwtHeaderToIssuerMapperDecider;
 import org.entur.jwt.spring.decode.JwtHeaderToIssuerMapperDecider;
 import org.entur.jwt.spring.decode.JwtHeaderToIssuerMapper;
 import org.entur.jwt.spring.properties.Auth0Flavour;
@@ -79,21 +77,6 @@ public class JwtWebFluxSecurityAutoConfiguration {
     @ConditionalOnMissingBean(JwtAuthorityEnricher.class)
     public JwtAuthorityEnricher jwtAuthorityEnricher() {
         return new DefaultJwtAuthorityEnricher();
-    }
-
-    @Bean
-    @ConditionalOnProperty(name = "entur.jwt.decode.header.map-to-issuer.enabled", havingValue = "true")
-    @ConditionalOnMissingBean(JwtHeaderToIssuerMapper.class)
-    public JwtHeaderToIssuerMapper jwtHeaderToIssuerMapper(SecurityProperties securityProperties) {
-        int maxSize = securityProperties.getJwt().getDecode().getHeader().getMapToIssuer().getMaxSize();
-        return maxSize != -1 ? new BoundedJwtHeaderToIssuerMapper(maxSize) : new JwtHeaderToIssuerMapper();
-    }
-
-    @Bean
-    @ConditionalOnProperty(name = "entur.jwt.decode.header.map-to-issuer.enabled", havingValue = "true")
-    @ConditionalOnMissingBean(JwtHeaderToIssuerMapperDecider.class)
-    public JwtHeaderToIssuerMapperDecider jwtHeaderToIssuerHeaderMapperDecider() {
-        return new DefaultJwtHeaderToIssuerMapperDecider();
     }
 
     @Configuration


### PR DESCRIPTION
Stronger way to ensure fixed bean init order.