### PR TITLE
Guard StatefulUrlAccessTokenProvider with a lock for standalone use

### DIFF
--- a/jwt-client/jwt-client-core/src/main/java/org/entur/jwt/client/AbstractStatefulUrlAccessTokenProvider.java
+++ b/jwt-client/jwt-client-core/src/main/java/org/entur/jwt/client/AbstractStatefulUrlAccessTokenProvider.java
@@ -3,6 +3,8 @@ package org.entur.jwt.client;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * {@linkplain AccessTokenProvider} which handles refresh tokens.
@@ -13,15 +15,42 @@ public abstract class AbstractStatefulUrlAccessTokenProvider extends AbstractUrl
 
     protected static final String KEY_REFRESH_TOKEN = "refresh_token";
 
+    // Default used by the deprecated constructor which does not take an explicit call timeout.
+    public static final long DEFAULT_CALL_TIMEOUT_MILLIS = TimeUnit.SECONDS.toMillis(30);
+
     protected final URL revokeUrl;
     protected final URL refreshUrl;
 
     protected volatile RefreshToken refreshToken;
 
+    // The maximum time to wait to acquire refreshLock in getAccessToken(long), in milliseconds.
+    private final long callTimeoutMillis;
+
+    // strictly not necessary if a wrapping provider has its own lock
+    private final ReentrantLock refreshLock = new ReentrantLock();
+
+    /**
+     * @deprecated use {@link #AbstractStatefulUrlAccessTokenProvider(URL, Map, Map, URL, URL, long)} instead,
+     * explicitly specifying the call timeout.
+     */
+    @Deprecated
     public AbstractStatefulUrlAccessTokenProvider(URL issueUrl, Map<String, Object> parameters, Map<String, Object> headers, URL refreshUrl, URL revokeUrl) {
+        this(issueUrl, parameters, headers, refreshUrl, revokeUrl, DEFAULT_CALL_TIMEOUT_MILLIS);
+    }
+
+    /**
+     * @param callTimeoutMillis the maximum time to wait to acquire the internal refresh lock in
+     *                          {@linkplain #getAccessToken(long)}, in milliseconds. Should not exceed
+     *                          the time a single token / refresh-token HTTP call is allowed to take.
+     */
+    public AbstractStatefulUrlAccessTokenProvider(URL issueUrl, Map<String, Object> parameters, Map<String, Object> headers, URL refreshUrl, URL revokeUrl, long callTimeoutMillis) {
         super(issueUrl, parameters, headers);
+
+        checkArgument(callTimeoutMillis > 0, "Invalid call timeout value '" + callTimeoutMillis + "'. Must be a positive value.");
+
         this.refreshUrl = refreshUrl;
         this.revokeUrl = revokeUrl;
+        this.callTimeoutMillis = callTimeoutMillis;
     }
 
     @Override
@@ -62,36 +91,58 @@ public abstract class AbstractStatefulUrlAccessTokenProvider extends AbstractUrl
         return getAccessToken(System.currentTimeMillis());
     }
 
+    /**
+     * @return the maximum time to wait to acquire the internal refresh lock in
+     * {@linkplain #getAccessToken(long)}, in milliseconds.
+     */
+    public long getCallTimeoutMillis() {
+        return callTimeoutMillis;
+    }
+
     public AccessToken getAccessToken(long time) throws AccessTokenException {
         // note: force refresh is not relevant for whether to use refresh-token or not
         ClientCredentialsResponse token;
 
-        RefreshToken threadSafeRefreshToken = this.refreshToken; // defensive copy
-        if (threadSafeRefreshToken != null && threadSafeRefreshToken.isValid(time)) {
-            try {
-                token = getToken(threadSafeRefreshToken);
-            } catch (RefreshTokenException e) {
-                // assume current session has been revoked or expired
-                // open a new session and forget about the old one
-                token = getToken();
-            }
-        } else {
-            token = getToken();
-        }
+        try {
+            if (refreshLock.tryLock(callTimeoutMillis, TimeUnit.MILLISECONDS)) {
+                try {
+                    RefreshToken threadSafeRefreshToken = this.refreshToken; // defensive copy
+                    if (threadSafeRefreshToken != null && threadSafeRefreshToken.isValid(time)) {
+                        try {
+                            token = getToken(threadSafeRefreshToken);
+                        } catch (RefreshTokenException e) {
+                            // assume current session has been revoked or expired
+                            // open a new session and forget about the old one
+                            token = getToken();
+                        }
+                    } else {
+                        token = getToken();
+                    }
 
-        if (token.getRefreshToken() != null) {
-            long expires;
+                    if (token.getRefreshToken() != null) {
+                        long expires;
 
-            // refresh token expiry is a non-standard claim
-            // so in other words it will not always be present
-            if (token.getRefreshExpiresIn() != null) {
-                expires = time + token.getRefreshExpiresIn() * 1000;
+                        // refresh token expiry is a non-standard claim
+                        // so in other words it will not always be present
+                        if (token.getRefreshExpiresIn() != null) {
+                            expires = time + token.getRefreshExpiresIn() * 1000;
+                        } else {
+                            expires = -1L;
+                        }
+                        this.refreshToken = new RefreshToken(token.getRefreshToken(), expires);
+                    } else {
+                        this.refreshToken = null;
+                    }
+                } finally {
+                    refreshLock.unlock();
+                }
             } else {
-                expires = -1L;
+                throw new AccessTokenUnavailableException("Timeout while waiting to refresh access token (limit of " + callTimeoutMillis + "ms exceeded).");
             }
-            this.refreshToken = new RefreshToken(token.getRefreshToken(), expires);
-        } else {
-            this.refreshToken = null;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt(); // Restore interrupted state to make sonar happy
+
+            throw new AccessTokenUnavailableException("Interrupted while waiting to refresh access token", e);
         }
 
         return new AccessToken(token.getAccessToken(), token.getTokenType(), time + token.getExpiresIn() * 1000);

--- a/jwt-client/jwt-client-core/src/main/java/org/entur/jwt/client/AbstractStatefulUrlAccessTokenProvider.java
+++ b/jwt-client/jwt-client-core/src/main/java/org/entur/jwt/client/AbstractStatefulUrlAccessTokenProvider.java
@@ -106,6 +106,7 @@ public abstract class AbstractStatefulUrlAccessTokenProvider extends AbstractUrl
         try {
             if (refreshLock.tryLock(callTimeoutMillis, TimeUnit.MILLISECONDS)) {
                 try {
+                    time = Math.max(time, System.currentTimeMillis());
                     RefreshToken threadSafeRefreshToken = this.refreshToken; // defensive copy
                     if (threadSafeRefreshToken != null && threadSafeRefreshToken.isValid(time)) {
                         try {

--- a/jwt-client/jwt-client-core/src/main/java/org/entur/jwt/client/AccessTokenProviderBuilder.java
+++ b/jwt-client/jwt-client-core/src/main/java/org/entur/jwt/client/AccessTokenProviderBuilder.java
@@ -15,7 +15,7 @@ public class AccessTokenProviderBuilder extends AbstractAccessTokenProvidersBuil
         } else if (revokeUrl != null && refreshUrl == null) {
             throw new IllegalStateException("Expected refresh url when revoke url is present");
         } else if (revokeUrl != null && refreshUrl != null) {
-            accessTokenProvider = new StatefulUrlAccessTokenProvider(credentials.getIssueURL(), credentials.getParameters(), credentials.getHeaders(), connectTimeout, readTimeout, refreshUrl, revokeUrl);
+            accessTokenProvider = new StatefulUrlAccessTokenProvider(credentials.getIssueURL(), credentials.getParameters(), credentials.getHeaders(), connectTimeout, readTimeout, refreshUrl, revokeUrl, AbstractStatefulUrlAccessTokenProvider.DEFAULT_CALL_TIMEOUT_MILLIS);
         } else {
             accessTokenProvider = new UrlAccessTokenProvider(credentials.getIssueURL(), credentials.getParameters(), credentials.getHeaders(), connectTimeout, readTimeout);
         }

--- a/jwt-client/jwt-client-core/src/main/java/org/entur/jwt/client/PreemptiveCachedAccessTokenProvider.java
+++ b/jwt-client/jwt-client-core/src/main/java/org/entur/jwt/client/PreemptiveCachedAccessTokenProvider.java
@@ -44,7 +44,7 @@ public class PreemptiveCachedAccessTokenProvider extends DefaultCachedAccessToke
     
     /** do not preemptively refresh before this percentage of a token's lifetime has passed */
     private final int refreshConstraintInPercent;
-    private ScheduledFuture<?> eagerScheduledFuture;
+    private volatile ScheduledFuture<?> eagerScheduledFuture;
     
 
     // cache expire time is used as its fingerprint

--- a/jwt-client/jwt-client-core/src/main/java/org/entur/jwt/client/StatefulUrlAccessTokenProvider.java
+++ b/jwt-client/jwt-client-core/src/main/java/org/entur/jwt/client/StatefulUrlAccessTokenProvider.java
@@ -28,8 +28,17 @@ public class StatefulUrlAccessTokenProvider extends AbstractStatefulUrlAccessTok
     protected final int readTimeout;
     protected final ObjectReader reader;
 
+    /**
+     * @deprecated use {@link #StatefulUrlAccessTokenProvider(URL, Map, Map, long, long, URL, URL, long)} instead,
+     * explicitly specifying the call timeout.
+     */
+    @Deprecated
     public StatefulUrlAccessTokenProvider(URL issueUrl, Map<String, Object> parameters, Map<String, Object> headers, long connectTimeout, long readTimeout, URL refreshUrl, URL revokeUrl) {
-        super(issueUrl, parameters, headers, refreshUrl, revokeUrl);
+        this(issueUrl, parameters, headers, connectTimeout, readTimeout, refreshUrl, revokeUrl, DEFAULT_CALL_TIMEOUT_MILLIS);
+    }
+
+    public StatefulUrlAccessTokenProvider(URL issueUrl, Map<String, Object> parameters, Map<String, Object> headers, long connectTimeout, long readTimeout, URL refreshUrl, URL revokeUrl, long callTimeoutMillis) {
+        super(issueUrl, parameters, headers, refreshUrl, revokeUrl, callTimeoutMillis);
 
         checkArgument(connectTimeout > 0 && connectTimeout <= Integer.MAX_VALUE, "Invalid connect timeout value '" + connectTimeout + "'. Must be a positive integer below or equal to " + Integer.MAX_VALUE + ".");
         checkArgument(readTimeout > 0 && readTimeout <= Integer.MAX_VALUE, "Invalid read timeout value '" + readTimeout + "'. Must be a positive integer below or equal to " + Integer.MAX_VALUE + ".");

--- a/jwt-client/jwt-client-core/src/test/java/org/entur/jwt/client/StatefulUrlAccessTokenProviderTest.java
+++ b/jwt-client/jwt-client-core/src/test/java/org/entur/jwt/client/StatefulUrlAccessTokenProviderTest.java
@@ -8,13 +8,22 @@ import java.io.ByteArrayOutputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -194,6 +203,120 @@ public class StatefulUrlAccessTokenProviderTest extends AbstractUrlAccessTokenPr
         assertThrows(AccessTokenUnavailableException.class, () -> {
             provider.getAccessToken(accessToken.getExpires() + 1);
         });
+    }
+
+    @Test
+    public void shouldWaitAndConsumeRotatedRefreshTokenWhenRequestsOverlap() throws Exception {
+        CountDownLatch thread1InGetTokenLatch = new CountDownLatch(1);
+        CountDownLatch thread1CanFinishLatch = new CountDownLatch(1);
+        List<String> consumedRefreshTokens = Collections.synchronizedList(new ArrayList<>());
+
+        StatefulUrlAccessTokenProvider provider = new StatefulUrlAccessTokenProvider(
+                mockUrl, Collections.emptyMap(), Collections.emptyMap(), 15000, 15000, mockUrl, mockUrl, 5000
+        ) {
+            @Override
+            protected ClientCredentialsResponse getToken(RefreshToken response) throws AccessTokenException {
+                consumedRefreshTokens.add(response.getValue());
+                if ("rt-1".equals(response.getValue())) {
+                    thread1InGetTokenLatch.countDown();
+                    try {
+                        thread1CanFinishLatch.await(5, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    ClientCredentialsResponse res = mock(ClientCredentialsResponse.class);
+                    when(res.getAccessToken()).thenReturn("at-2");
+                    when(res.getTokenType()).thenReturn("Bearer");
+                    when(res.getExpiresIn()).thenReturn(3600L);
+                    when(res.getRefreshToken()).thenReturn("rt-2");
+                    when(res.getRefreshExpiresIn()).thenReturn(3600L);
+                    return res;
+                } else if ("rt-2".equals(response.getValue())) {
+                    ClientCredentialsResponse res = mock(ClientCredentialsResponse.class);
+                    when(res.getAccessToken()).thenReturn("at-3");
+                    when(res.getTokenType()).thenReturn("Bearer");
+                    when(res.getExpiresIn()).thenReturn(3600L);
+                    when(res.getRefreshToken()).thenReturn("rt-3");
+                    when(res.getRefreshExpiresIn()).thenReturn(3600L);
+                    return res;
+                }
+                return super.getToken(response);
+            }
+        };
+
+        provider.refreshToken = new RefreshToken("rt-1", System.currentTimeMillis() + 100000);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            long now = System.currentTimeMillis();
+
+            Future<AccessToken> future1 = executor.submit(() -> provider.getAccessToken(now));
+
+            assertThat(thread1InGetTokenLatch.await(5, TimeUnit.SECONDS)).isTrue();
+
+            Future<AccessToken> future2 = executor.submit(() -> provider.getAccessToken(now));
+
+            Thread.sleep(100);
+
+            thread1CanFinishLatch.countDown();
+
+            AccessToken token1 = future1.get(5, TimeUnit.SECONDS);
+            AccessToken token2 = future2.get(5, TimeUnit.SECONDS);
+
+            assertThat(token1.getValue()).isEqualTo("at-2");
+            assertThat(token2.getValue()).isEqualTo("at-3");
+
+            assertThat(consumedRefreshTokens).containsExactly("rt-1", "rt-2").inOrder();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void shouldThrowAccessTokenUnavailableExceptionOnLockTimeout() throws Exception {
+        CountDownLatch thread1InLockLatch = new CountDownLatch(1);
+        CountDownLatch thread1CanFinishLatch = new CountDownLatch(1);
+
+        StatefulUrlAccessTokenProvider provider = new StatefulUrlAccessTokenProvider(
+                mockUrl, Collections.emptyMap(), Collections.emptyMap(), 15000, 15000, mockUrl, mockUrl, 100
+        ) {
+            @Override
+            protected ClientCredentialsResponse getToken(RefreshToken response) throws AccessTokenException {
+                thread1InLockLatch.countDown();
+                try {
+                    thread1CanFinishLatch.await(5, TimeUnit.SECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                ClientCredentialsResponse res = mock(ClientCredentialsResponse.class);
+                when(res.getAccessToken()).thenReturn("at-1");
+                when(res.getTokenType()).thenReturn("Bearer");
+                when(res.getExpiresIn()).thenReturn(3600L);
+                return res;
+            }
+        };
+
+        provider.refreshToken = new RefreshToken("rt-1", System.currentTimeMillis() + 100000);
+
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            long now = System.currentTimeMillis();
+
+            Future<AccessToken> future1 = executor.submit(() -> provider.getAccessToken(now));
+
+            assertThat(thread1InLockLatch.await(5, TimeUnit.SECONDS)).isTrue();
+
+            Future<AccessToken> future2 = executor.submit(() -> provider.getAccessToken(now));
+
+            ExecutionException exception = assertThrows(ExecutionException.class, () -> future2.get(5, TimeUnit.SECONDS));
+            assertThat(exception.getCause()).isInstanceOf(AccessTokenUnavailableException.class);
+            assertThat(exception.getCause().getMessage()).contains("Timeout while waiting to refresh access token");
+
+            thread1CanFinishLatch.countDown();
+            future1.get(5, TimeUnit.SECONDS);
+        } finally {
+            executor.shutdownNow();
+        }
     }
 
 }

--- a/jwt-client/jwt-client-spring-resttemplate/src/main/java/org/entur/jwt/client/spring/resttemplate/RestTemplateJwtClientBeanDefinitionRegistryPostProcessorSupport.java
+++ b/jwt-client/jwt-client-spring-resttemplate/src/main/java/org/entur/jwt/client/spring/resttemplate/RestTemplateJwtClientBeanDefinitionRegistryPostProcessorSupport.java
@@ -1,5 +1,6 @@
 package org.entur.jwt.client.spring.resttemplate;
 
+import org.entur.jwt.client.AbstractStatefulUrlAccessTokenProvider;
 import org.entur.jwt.client.AccessTokenProvider;
 import org.entur.jwt.client.ClientCredentials;
 import org.entur.jwt.client.properties.JwtClientProperties;
@@ -22,6 +23,6 @@ public class RestTemplateJwtClientBeanDefinitionRegistryPostProcessorSupport ext
 
     @Override
     protected AccessTokenProvider newStatefulUrlAccessTokenProvider(RestTemplate client, URL issueURL, Map<String, Object> parameters, Map<String, Object> headers, URL refreshUrl, URL revokeUrl, ClientCredentials credentials) {
-        return new RestTemplateStatefulUrlAccessTokenProvider(client, credentials.getIssueURL(), credentials.getParameters(), credentials.getHeaders(), refreshUrl, revokeUrl);
+        return new RestTemplateStatefulUrlAccessTokenProvider(client, credentials.getIssueURL(), credentials.getParameters(), credentials.getHeaders(), refreshUrl, revokeUrl, AbstractStatefulUrlAccessTokenProvider.DEFAULT_CALL_TIMEOUT_MILLIS);
     }
 }

--- a/jwt-client/jwt-client-spring-resttemplate/src/main/java/org/entur/jwt/client/spring/resttemplate/RestTemplateStatefulUrlAccessTokenProvider.java
+++ b/jwt-client/jwt-client-spring-resttemplate/src/main/java/org/entur/jwt/client/spring/resttemplate/RestTemplateStatefulUrlAccessTokenProvider.java
@@ -39,8 +39,17 @@ public class RestTemplateStatefulUrlAccessTokenProvider extends AbstractStateful
 
     protected final RestTemplate restTemplate;
 
+    /**
+     * @deprecated use {@link #RestTemplateStatefulUrlAccessTokenProvider(RestTemplate, URL, Map, Map, URL, URL, long)}
+     * instead, explicitly specifying the call timeout.
+     */
+    @Deprecated
     public RestTemplateStatefulUrlAccessTokenProvider(RestTemplate restTemplate, URL issueUrl, Map<String, Object> parameters, Map<String, Object> headers, URL refreshUrl, URL revokeUrl) {
-        super(issueUrl, parameters, headers, refreshUrl, revokeUrl);
+        this(restTemplate, issueUrl, parameters, headers, refreshUrl, revokeUrl, DEFAULT_CALL_TIMEOUT_MILLIS);
+    }
+
+    public RestTemplateStatefulUrlAccessTokenProvider(RestTemplate restTemplate, URL issueUrl, Map<String, Object> parameters, Map<String, Object> headers, URL refreshUrl, URL revokeUrl, long callTimeoutMillis) {
+        super(issueUrl, parameters, headers, refreshUrl, revokeUrl, callTimeoutMillis);
         this.restTemplate = restTemplate;
     }
 

--- a/jwt-client/jwt-client-spring-webflux/src/main/java/org/entur/jwt/client/spring/webflux/WebClientStatefulUrlAccessTokenProvider.java
+++ b/jwt-client/jwt-client-spring-webflux/src/main/java/org/entur/jwt/client/spring/webflux/WebClientStatefulUrlAccessTokenProvider.java
@@ -35,8 +35,17 @@ public class WebClientStatefulUrlAccessTokenProvider extends AbstractStatefulUrl
 
     protected final WebClient webClient;
 
+    /**
+     * @deprecated use {@link #WebClientStatefulUrlAccessTokenProvider(WebClient, URL, Map, Map, URL, URL, long)}
+     * instead, explicitly specifying the call timeout.
+     */
+    @Deprecated
     public WebClientStatefulUrlAccessTokenProvider(WebClient webClient, URL issueUrl, Map<String, Object> parameters, Map<String, Object> headers, URL refreshUrl, URL revokeUrl) {
-        super(issueUrl, parameters, headers, refreshUrl, revokeUrl);
+        this(webClient, issueUrl, parameters, headers, refreshUrl, revokeUrl, DEFAULT_CALL_TIMEOUT_MILLIS);
+    }
+
+    public WebClientStatefulUrlAccessTokenProvider(WebClient webClient, URL issueUrl, Map<String, Object> parameters, Map<String, Object> headers, URL refreshUrl, URL revokeUrl, long callTimeoutMillis) {
+        super(issueUrl, parameters, headers, refreshUrl, revokeUrl, callTimeoutMillis);
         this.webClient = webClient;
     }
 

--- a/jwt-client/jwt-client-spring-webflux/src/main/java/org/entur/jwt/client/spring/webflux/WebfluxJwtClientBeanDefinitionRegistryPostProcessorSupport.java
+++ b/jwt-client/jwt-client-spring-webflux/src/main/java/org/entur/jwt/client/spring/webflux/WebfluxJwtClientBeanDefinitionRegistryPostProcessorSupport.java
@@ -1,5 +1,6 @@
 package org.entur.jwt.client.spring.webflux;
 
+import org.entur.jwt.client.AbstractStatefulUrlAccessTokenProvider;
 import org.entur.jwt.client.AccessTokenProvider;
 import org.entur.jwt.client.ClientCredentials;
 import org.entur.jwt.client.properties.JwtClientProperties;
@@ -22,6 +23,6 @@ public class WebfluxJwtClientBeanDefinitionRegistryPostProcessorSupport extends 
 
     @Override
     protected AccessTokenProvider newStatefulUrlAccessTokenProvider(WebClient client, URL issueURL, Map<String, Object> parameters, Map<String, Object> headers, URL refreshUrl, URL revokeUrl, ClientCredentials credentials) {
-        return new WebClientStatefulUrlAccessTokenProvider(client, credentials.getIssueURL(), credentials.getParameters(), credentials.getHeaders(), refreshUrl, revokeUrl);
+        return new WebClientStatefulUrlAccessTokenProvider(client, credentials.getIssueURL(), credentials.getParameters(), credentials.getHeaders(), refreshUrl, revokeUrl, AbstractStatefulUrlAccessTokenProvider.DEFAULT_CALL_TIMEOUT_MILLIS);
     }
 }

--- a/jwt-client/jwt-client-spring/src/main/java/org/entur/jwt/client/spring/restclient/RestClientJwtClientBeanDefinitionRegistryPostProcessorSupport.java
+++ b/jwt-client/jwt-client-spring/src/main/java/org/entur/jwt/client/spring/restclient/RestClientJwtClientBeanDefinitionRegistryPostProcessorSupport.java
@@ -1,5 +1,6 @@
 package org.entur.jwt.client.spring.restclient;
 
+import org.entur.jwt.client.AbstractStatefulUrlAccessTokenProvider;
 import org.entur.jwt.client.AccessTokenProvider;
 import org.entur.jwt.client.ClientCredentials;
 import org.entur.jwt.client.properties.JwtClientProperties;
@@ -22,6 +23,6 @@ public class RestClientJwtClientBeanDefinitionRegistryPostProcessorSupport exten
 
     @Override
     protected AccessTokenProvider newStatefulUrlAccessTokenProvider(RestClient client, URL issueURL, Map<String, Object> parameters, Map<String, Object> headers, URL refreshUrl, URL revokeUrl, ClientCredentials credentials) {
-        return new RestClientStatefulUrlAccessTokenProvider(client, credentials.getIssueURL(), credentials.getParameters(), credentials.getHeaders(), refreshUrl, revokeUrl);
+        return new RestClientStatefulUrlAccessTokenProvider(client, credentials.getIssueURL(), credentials.getParameters(), credentials.getHeaders(), refreshUrl, revokeUrl, AbstractStatefulUrlAccessTokenProvider.DEFAULT_CALL_TIMEOUT_MILLIS);
     }
 }

--- a/jwt-client/jwt-client-spring/src/main/java/org/entur/jwt/client/spring/restclient/RestClientStatefulUrlAccessTokenProvider.java
+++ b/jwt-client/jwt-client-spring/src/main/java/org/entur/jwt/client/spring/restclient/RestClientStatefulUrlAccessTokenProvider.java
@@ -33,8 +33,17 @@ public class RestClientStatefulUrlAccessTokenProvider extends AbstractStatefulUr
 
     protected final RestClient restClient;
 
+    /**
+     * @deprecated use {@link #RestClientStatefulUrlAccessTokenProvider(RestClient, URL, Map, Map, URL, URL, long)}
+     * instead, explicitly specifying the call timeout.
+     */
+    @Deprecated
     public RestClientStatefulUrlAccessTokenProvider(RestClient restClient, URL issueUrl, Map<String, Object> parameters, Map<String, Object> headers, URL refreshUrl, URL revokeUrl) {
-        super(issueUrl, parameters, headers, refreshUrl, revokeUrl);
+        this(restClient, issueUrl, parameters, headers, refreshUrl, revokeUrl, DEFAULT_CALL_TIMEOUT_MILLIS);
+    }
+
+    public RestClientStatefulUrlAccessTokenProvider(RestClient restClient, URL issueUrl, Map<String, Object> parameters, Map<String, Object> headers, URL refreshUrl, URL revokeUrl, long callTimeoutMillis) {
+        super(issueUrl, parameters, headers, refreshUrl, revokeUrl, callTimeoutMillis);
         this.restClient = restClient;
     }
 


### PR DESCRIPTION
In most cases the above (wrapping) provider has a cache-with-lock mechanism already. 

This makes extra sure that refresh tokens are not rotated and reused by a concurrent call. 

Since there is a Lock we also need to pass a timeout so that nothing can block forever.

TODO: Better to create a generic wrapper and use it when appropriate?